### PR TITLE
Add Silero VAD streaming integration and CLI visualization

### DIFF
--- a/task.md
+++ b/task.md
@@ -6,7 +6,7 @@
 - [x] Provide audio loopback demo with CLI dots visualizer.
 - [x] Integrate Kitten TTS asset handling, voice listing, and playback commands.
 - [x] Add bootstrap script for macOS/Linux including model downloads.
-- [ ] Implement Silero VAD streaming integration.
+- [x] Implement Silero VAD streaming integration.
 - [ ] Integrate MLX Whisper and Faster-Whisper ASR backends.
 - [ ] Add llama.cpp GGUF streaming inference runner.
 - [ ] Implement Smart-Turn v2 orchestration and unit tests.

--- a/tests/test_silero_vad.py
+++ b/tests/test_silero_vad.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from voice_agent.vad import SileroVadConfig, SileroVadStream, VadState
+
+
+class FakeModel:
+    def __init__(self, probabilities: list[float]) -> None:
+        self.probabilities = probabilities
+        self.index = 0
+        self.reset_called = 0
+
+    def reset_states(self) -> None:
+        self.reset_called += 1
+        self.index = 0
+
+    def __call__(self, chunk: np.ndarray, sample_rate: int) -> float:
+        if self.index >= len(self.probabilities):
+            return 0.0
+        value = self.probabilities[self.index]
+        self.index += 1
+        return value
+
+
+class CountingModel:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.reset_called = 0
+
+    def reset_states(self) -> None:
+        self.reset_called += 1
+
+    def __call__(self, chunk: np.ndarray, sample_rate: int) -> float:
+        self.calls += 1
+        # return low confidence so no events fire
+        return 0.0
+
+
+def _build_stream(probabilities: list[float]) -> SileroVadStream:
+    config = SileroVadConfig(
+        model_path=Path("silero_vad.onnx"),
+        sample_rate=16000,
+        trigger_level=0.6,
+        release_level=0.3,
+        sensitivity=1.0,
+        frame_size=512,
+    )
+    audio_chunks = [np.ones(config.frame_size, dtype=np.float32) for _ in probabilities]
+    model = FakeModel(probabilities)
+    stream = SileroVadStream(audio_chunks, config, model=model)
+    return stream
+
+
+def test_silero_vad_stream_transitions():
+    stream = _build_stream([0.05, 0.7, 0.8, 0.9, 0.85, 0.2, 0.1, 0.05, 0.05])
+    events = list(stream)
+    assert [event.state for event in events] == [VadState.SPEECH, VadState.SILENCE]
+    assert events[0].timestamp == pytest.approx(0.064, rel=1e-2)
+    assert events[1].timestamp == pytest.approx(0.288, rel=1e-2)
+    assert events[0].confidence == pytest.approx(0.61, rel=1e-2)
+    assert events[1].confidence == pytest.approx(0.052, rel=1e-2)
+
+
+def test_from_numpy_yields_expected_frames():
+    audio = np.ones(1200, dtype=np.float32)
+    model = CountingModel()
+    stream = SileroVadStream.from_numpy(
+        audio,
+        model_path=Path("silero_vad.onnx"),
+        sample_rate=16000,
+        trigger_level=0.6,
+        release_level=0.3,
+        sensitivity=0.5,
+        frame_size=512,
+        model=model,
+    )
+    events = list(stream)
+    assert events == []
+    assert model.calls == 3
+    assert model.reset_called == 1
+

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -16,6 +16,7 @@ from voice_agent.cli.visualizer import DotsVisualizer
 from voice_agent.config import ConfigManager
 from voice_agent.logging import configure_logging, get_logger
 from voice_agent.tts import KittenTTS, load_voice_inventory
+from voice_agent.vad import SileroVadError, SileroVadStream
 
 app = typer.Typer(add_completion=False, help="Cross-platform voice agent runtime")
 profile_app = typer.Typer(help="Manage configuration profiles")
@@ -52,11 +53,47 @@ def run(
     """Run an audio loopback demo with the dot visualizer."""
 
     manager = _config_manager(config_path)
-    manager.load()
+    config = manager.load()
     audio = AudioIO(samplerate=16000)
     visualizer = DotsVisualizer()
     data = audio.record_loopback(seconds=seconds, input_device=input_device, output_device=output_device)
-    visualizer.run_demo(data)
+    profile = config.active()
+    vad_model_path = profile.vad.model_path.expanduser()
+    try:
+        vad_stream = SileroVadStream.from_numpy(
+            audio=data,
+            model_path=vad_model_path,
+            sample_rate=audio.samplerate,
+            trigger_level=profile.vad.trigger_level,
+            release_level=profile.vad.release_level,
+            sensitivity=profile.vad.sensitivity,
+        )
+    except FileNotFoundError as exc:
+        _LOG.warning(
+            "VAD model missing",
+            extra={
+                "classname": "CLI",
+                "function": "run",
+                "system_section": "vad",
+                "error": str(exc),
+                "message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+            },
+        )
+        visualizer.run_demo(data)
+    except SileroVadError as exc:
+        _LOG.error(
+            "VAD initialisation failed",
+            extra={
+                "classname": "CLI",
+                "function": "run",
+                "system_section": "vad",
+                "error": str(exc),
+                "message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+            },
+        )
+        visualizer.run_demo(data)
+    else:
+        visualizer.render_vad(vad_stream, fallback_audio=data)
     typer.echo("Loopback complete")
 
 

--- a/voice_agent/cli/visualizer.py
+++ b/voice_agent/cli/visualizer.py
@@ -10,6 +10,7 @@ from typing import Iterable
 
 import numpy as np
 
+from voice_agent.vad import VadEvent, VadState
 
 @dataclass
 class VisualizerConfig:
@@ -42,6 +43,28 @@ class DotsVisualizer:
             sys.stdout.write(f"[{state:>8}] {bar}\n")
             sys.stdout.flush()
             time.sleep(self.config.refresh_rate)
+
+    def render_vad(self, events: Iterable[VadEvent], fallback_audio: np.ndarray | None = None) -> None:
+        sys.stdout.write("VAD State:\n")
+        sys.stdout.flush()
+        last_timestamp = 0.0
+        last_state = VadState.SILENCE
+        count = 0
+        for event in events:
+            count += 1
+            last_timestamp = event.timestamp
+            last_state = event.state
+            bar = "█" * min(10, int(round(event.confidence * 10)))
+            sys.stdout.write(
+                f"[{event.state.value:>7}] {bar:<10} @ {event.timestamp:5.2f}s\n"
+            )
+            sys.stdout.flush()
+            time.sleep(self.config.refresh_rate)
+        if count == 0 and fallback_audio is not None:
+            self.render_audio(fallback_audio)
+        elif count and last_state is not VadState.SILENCE:  # ensure terminal silence marker
+            sys.stdout.write(f"[{VadState.SILENCE.value:>7}] {'':10} @ {last_timestamp:5.2f}s\n")
+            sys.stdout.flush()
 
     def render_tokens(self, token_stream: Iterable[str], duration: float = 0.5) -> None:
         sys.stdout.write("LLM Tokens:\n")

--- a/voice_agent/config/default_config.toml
+++ b/voice_agent/config/default_config.toml
@@ -12,7 +12,7 @@ llm_temperature = 0.7
 llm_top_p = 0.9
 llm_repeat_penalty = 1.1
 
-vad_model = "assets/vad/silero_vad.jit"
+vad_model = "assets/vad/silero_vad.onnx"
 vad_trigger_level = 0.5
 vad_release_level = 0.35
 vad_sensitivity = 0.6
@@ -42,7 +42,7 @@ llm_temperature = 0.8
 llm_top_p = 0.9
 llm_repeat_penalty = 1.05
 
-vad_model = "assets/vad/silero_vad.jit"
+vad_model = "assets/vad/silero_vad.onnx"
 vad_trigger_level = 0.55
 vad_release_level = 0.3
 vad_sensitivity = 0.5

--- a/voice_agent/vad/__init__.py
+++ b/voice_agent/vad/__init__.py
@@ -1,5 +1,13 @@
 """Voice activity detection abstractions."""
 
 from .base import VadEvent, VadState, VadStream
+from .silero import SileroVadConfig, SileroVadError, SileroVadStream
 
-__all__ = ["VadEvent", "VadState", "VadStream"]
+__all__ = [
+    "VadEvent",
+    "VadState",
+    "VadStream",
+    "SileroVadConfig",
+    "SileroVadStream",
+    "SileroVadError",
+]

--- a/voice_agent/vad/silero.py
+++ b/voice_agent/vad/silero.py
@@ -1,0 +1,207 @@
+"""Silero VAD streaming integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+import numpy as np
+
+from voice_agent.logging import get_logger
+from voice_agent.vad.base import VadEvent, VadState, VadStream
+
+try:  # pragma: no cover - optional dependency at runtime
+    import onnxruntime as _ort
+except Exception:  # pragma: no cover - we raise a structured error during initialisation
+    _ort = None  # type: ignore[assignment]
+
+
+class SileroVadError(RuntimeError):
+    """Raised when Silero VAD cannot be initialised."""
+
+
+class _SileroOnnxModel:
+    """Minimal ONNX wrapper replicating Silero streaming behaviour."""
+
+    def __init__(self, model_path: Path, sample_rate: int) -> None:
+        if _ort is None:
+            raise SileroVadError("onnxruntime is required for Silero VAD; install extras with poetry install")
+        if not model_path.exists():
+            raise FileNotFoundError(f"Silero VAD model missing: {model_path}")
+
+        opts = _ort.SessionOptions()
+        opts.inter_op_num_threads = 1
+        opts.intra_op_num_threads = 1
+        providers = ["CPUExecutionProvider"] if "CPUExecutionProvider" in _ort.get_available_providers() else None
+        self._session = _ort.InferenceSession(str(model_path), providers=providers, sess_options=opts)
+        self._sr = sample_rate
+        if self._sr not in (8000, 16000):
+            raise SileroVadError("Silero VAD supports 8 kHz or 16 kHz audio")
+        self._context_width = 64 if self._sr == 16000 else 32
+        self._frame_samples = 512 if self._sr == 16000 else 256
+        self.reset_states()
+
+    def reset_states(self, batch_size: int = 1) -> None:
+        self._state = np.zeros((2, batch_size, 128), dtype=np.float32)
+        self._context = np.zeros((batch_size, self._context_width), dtype=np.float32)
+
+    def __call__(self, chunk: np.ndarray, sample_rate: int) -> float:
+        if sample_rate != self._sr:
+            raise SileroVadError(f"Silero model initialised for {self._sr} Hz, received {sample_rate} Hz")
+
+        if chunk.ndim == 1:
+            chunk = chunk[np.newaxis, :]
+        if chunk.ndim != 2:
+            raise SileroVadError(f"Unexpected chunk dimensions: {chunk.shape}")
+
+        num_samples = chunk.shape[1]
+        if num_samples < self._frame_samples:
+            padded = np.zeros((chunk.shape[0], self._frame_samples), dtype=np.float32)
+            padded[:, :num_samples] = chunk
+            chunk = padded
+        elif num_samples > self._frame_samples:
+            raise SileroVadError(
+                f"Silero VAD expects {self._frame_samples} samples per frame; received {num_samples}"
+            )
+
+        chunk = chunk.astype(np.float32, copy=False)
+        model_input = np.concatenate([self._context, chunk], axis=1)
+        ort_inputs = {
+            "input": model_input,
+            "state": self._state,
+            "sr": np.array(self._sr, dtype=np.int64),
+        }
+        out, state = self._session.run(None, ort_inputs)
+        self._state = state.astype(np.float32)
+        self._context = model_input[:, -self._context_width :]
+        prob = float(out.squeeze())
+        return prob
+
+
+@dataclass
+class SileroVadConfig:
+    model_path: Path
+    sample_rate: int
+    trigger_level: float
+    release_level: float
+    sensitivity: float
+    frame_size: int = 512
+
+
+class SileroVadStream(VadStream):
+    """Stream VAD events by running the Silero ONNX model over audio frames."""
+
+    def __init__(
+        self,
+        audio_source: Iterable[np.ndarray],
+        config: SileroVadConfig,
+        *,
+        model: Optional[_SileroOnnxModel] = None,
+    ) -> None:
+        self._audio_source = audio_source
+        self._config = config
+        self._frame_size = config.frame_size
+        self._frame_seconds = self._frame_size / float(config.sample_rate)
+        self._model = model or _SileroOnnxModel(config.model_path, config.sample_rate)
+        self._state = VadState.SILENCE
+        self._timestamp = 0.0
+        self._smoothed = config.release_level
+        self._sensitivity = float(np.clip(config.sensitivity, 0.0, 1.0))
+        self._trigger_hold_frames = max(1, int(round(self._compute_hold_seconds(0.04) / self._frame_seconds)))
+        self._release_hold_frames = max(1, int(round(self._compute_hold_seconds(0.12) / self._frame_seconds)))
+        self._active_frames = 0
+        self._inactive_frames = 0
+        self._logger = get_logger(f"{__name__}.SileroVadStream")
+        self._model.reset_states()
+
+    def _compute_hold_seconds(self, base: float) -> float:
+        span = 0.18  # seconds of variability across sensitivity range
+        return max(0.02, base + (1.0 - self._sensitivity) * span)
+
+    def _smooth(self, prob: float) -> float:
+        alpha = 0.25 + 0.6 * self._sensitivity
+        self._smoothed = alpha * prob + (1.0 - alpha) * self._smoothed
+        return self._smoothed
+
+    def _frame_iter(self, chunk: np.ndarray) -> Iterator[np.ndarray]:
+        data = np.asarray(chunk, dtype=np.float32).flatten()
+        if data.size == 0:
+            return
+        for start in range(0, data.size, self._frame_size):
+            frame = data[start : start + self._frame_size]
+            if frame.size < self._frame_size:
+                padded = np.zeros(self._frame_size, dtype=np.float32)
+                padded[: frame.size] = frame
+                frame = padded
+            yield frame
+
+    def __iter__(self) -> Iterator[VadEvent]:
+        for chunk in self._audio_source:
+            for frame in self._frame_iter(chunk):
+                prob = self._model(frame, self._config.sample_rate)
+                confidence = self._smooth(prob)
+                self._timestamp += self._frame_seconds
+                if confidence >= self._config.trigger_level:
+                    self._active_frames += 1
+                    self._inactive_frames = 0
+                elif confidence <= self._config.release_level:
+                    self._inactive_frames += 1
+                    self._active_frames = 0
+                else:
+                    self._active_frames = 0
+                    self._inactive_frames = 0
+
+                if self._state is VadState.SILENCE and self._active_frames >= self._trigger_hold_frames:
+                    self._state = VadState.SPEECH
+                    self._active_frames = 0
+                    self._logger.info(
+                        "[Continuous skepticism (Sherlock Protocol)] Speech detected",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "__iter__",
+                            "system_section": "vad",
+                        },
+                    )
+                    yield VadEvent(state=VadState.SPEECH, confidence=confidence, timestamp=self._timestamp)
+                elif self._state is VadState.SPEECH and self._inactive_frames >= self._release_hold_frames:
+                    self._state = VadState.SILENCE
+                    self._inactive_frames = 0
+                    self._logger.info(
+                        "[Continuous skepticism (Sherlock Protocol)] Speech ended",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "__iter__",
+                            "system_section": "vad",
+                        },
+                    )
+                    yield VadEvent(state=VadState.SILENCE, confidence=confidence, timestamp=self._timestamp)
+
+    @classmethod
+    def from_numpy(
+        cls,
+        audio: np.ndarray,
+        *,
+        model_path: Path,
+        sample_rate: int,
+        trigger_level: float,
+        release_level: float,
+        sensitivity: float,
+        frame_size: int = 512,
+        model: Optional[_SileroOnnxModel] = None,
+    ) -> "SileroVadStream":
+        def generator() -> Iterator[np.ndarray]:
+            yield audio
+
+        config = SileroVadConfig(
+            model_path=model_path,
+            sample_rate=sample_rate,
+            trigger_level=trigger_level,
+            release_level=release_level,
+            sensitivity=sensitivity,
+            frame_size=frame_size,
+        )
+        return cls(generator(), config, model=model)
+
+
+__all__ = ["SileroVadConfig", "SileroVadStream", "SileroVadError"]


### PR DESCRIPTION
## Summary
- implement an ONNX-backed Silero VAD stream with smoothing, hysteresis, and numpy frame handling
- wire the CLI loopback command and visualizer to render Silero VAD events with structured logging fallback
- add regression tests for the VAD stream and update default configuration/tasks to use the ONNX model

## Testing
- PYTHONPATH=. poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e672a1968c832b9c369670d9eee996