### PR TITLE
Add llama.cpp streaming runner and CLI benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 - Terminal dots visualizer showing VAD states, ASR partials, and simulated LLM token flow.
 - Kitten TTS integration with ONNXRuntime fallback, voice inventory tooling, and CLI preview playback.
 - Model fetcher with resumable downloads, bootstrap script for Linux/macOS, and placeholder benchmarking commands.
+- llama.cpp GGUF streaming runner with CLI streaming benchmark tooling.
 
 ## Getting Started
 
@@ -46,6 +47,7 @@ Common commands:
 - `poetry run voice-agent tts list` — list available Kitten voices (requires assets present).
 - `poetry run voice-agent tts sample --voice kitten/en_female_01 "Hello there"` — play a sample clip.
 - `poetry run voice-agent models pull tts/kitten-nano-0.2` — fetch Kitten TTS model assets.
+- `poetry run voice-agent bench llm "Hello"` — stream llama.cpp tokens for a quick sanity check.
 - `poetry run voice-agent bench latency` — measure loopback latency.
 
 ### Configuration

--- a/poetry.lock
+++ b/poetry.lock
@@ -313,6 +313,18 @@ pyyaml = ">=5.3,<7"
 setuptools = "*"
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+description = "Disk Cache -- Disk and file backed persistent cache."
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+files = [
+    {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
+    {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
+]
+
+[[package]]
 name = "faster-whisper"
 version = "1.2.0"
 description = "Faster Whisper transcription with CTranslate2"
@@ -513,10 +525,9 @@ files = [
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
-optional = true
+optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"asr\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -527,6 +538,29 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "llama-cpp-python"
+version = "0.2.90"
+description = "Python bindings for the llama.cpp library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "llama_cpp_python-0.2.90.tar.gz", hash = "sha256:419b041c62dbdb9f7e67883a6ef2f247d583d08417058776be0bff05b4ec9e3d"},
+]
+
+[package.dependencies]
+diskcache = ">=5.6.1"
+jinja2 = ">=2.11.3"
+numpy = ">=1.20.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+all = ["llama_cpp_python[dev,server,test]"]
+dev = ["black (>=23.3.0)", "httpx (>=0.24.1)", "mkdocs (>=1.4.3)", "mkdocs-material (>=9.1.18)", "mkdocstrings[python] (>=0.22.0)", "pytest (>=7.4.0)", "twine (>=4.0.2)"]
+server = ["PyYAML (>=5.1)", "fastapi (>=0.100.0)", "pydantic-settings (>=2.0.1)", "sse-starlette (>=1.6.1)", "starlette-context (>=0.3.6,<0.4)", "uvicorn (>=0.22.0)"]
+test = ["fastapi (>=0.100.0)", "httpx (>=0.24.1)", "pydantic-settings (>=2.0.1)", "pytest (>=7.4.0)", "scipy (>=1.10)", "sse-starlette (>=1.6.1)", "starlette-context (>=0.3.6,<0.4)"]
 
 [[package]]
 name = "llvmlite"
@@ -588,10 +622,9 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
 name = "markupsafe"
 version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"asr\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2224,4 +2257,4 @@ tts = ["onnxruntime"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "fb60b4d5e18b7a0d3b9d7fd1aacdafcb331a45f2fa0af9dc8c7fb444451cce97"
+content-hash = "59037106180c1745d4f5a066d7812d0d890d438c5f27960876b41e2c172a7d51"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ scipy = "^1.12.0"
 tomli-w = "^1.0.0"
 faster-whisper = { version = "^1.2.0", optional = true }
 mlx-whisper = { version = "^0.4.3", optional = true }
+llama-cpp-python = "^0.2.60"
 
 [tool.poetry.extras]
 tts = ["onnxruntime"]

--- a/task.md
+++ b/task.md
@@ -8,7 +8,7 @@
 - [x] Add bootstrap script for macOS/Linux including model downloads.
 - [x] Implement Silero VAD streaming integration.
 - [x] Integrate MLX Whisper and Faster-Whisper ASR backends.
-- [ ] Add llama.cpp GGUF streaming inference runner.
+- [x] Add llama.cpp GGUF streaming inference runner.
 - [ ] Implement Smart-Turn v2 orchestration and unit tests.
 - [ ] Build benchmarking tools for LLM, ASR, and TTS latency.
 - [ ] Extend packaging and telemetry features.

--- a/tests/test_llm_llama_cpp.py
+++ b/tests/test_llm_llama_cpp.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from voice_agent.llm import LlmConfig, LlamaCppEngine, create_llm_engine
+
+
+def _write_dummy_model(path: Path) -> None:
+    path.write_bytes(b"gguf")
+
+
+def test_create_engine_loads_model(tmp_path: Path, mocker) -> None:
+    model_path = tmp_path / "model.gguf"
+    _write_dummy_model(model_path)
+    mock_llama = mocker.Mock()
+    mock_llama.return_value.create_completion.return_value = iter(())
+
+    config = LlmConfig(
+        model_path=model_path,
+        temperature=0.5,
+        top_p=0.8,
+        repeat_penalty=1.05,
+        context_window=1024,
+    )
+
+    with mock.patch.dict(sys.modules, {"llama_cpp": SimpleNamespace(Llama=mock_llama)}):
+        engine = create_llm_engine(config)
+
+    assert isinstance(engine, LlamaCppEngine)
+    mock_llama.assert_called_once_with(model_path=str(model_path), n_ctx=1024)
+
+
+def test_stream_yields_chunks(tmp_path: Path, mocker) -> None:
+    model_path = tmp_path / "model.gguf"
+    _write_dummy_model(model_path)
+
+    chunks = iter(
+        [
+            {"choices": [{"text": "Hello"}]},
+            {"choices": [{"text": " world"}]},
+            {"choices": [{"text": "!"}]},
+        ]
+    )
+
+    mock_llama = mocker.Mock()
+    mock_llama.return_value.create_completion.return_value = chunks
+
+    config = LlmConfig(model_path=model_path)
+    with mock.patch.dict(sys.modules, {"llama_cpp": SimpleNamespace(Llama=mock_llama)}):
+        engine = create_llm_engine(config)
+
+    result = list(engine.stream(prompt="Hi", max_tokens=5))
+
+    assert result == ["Hello", " world", "!"]
+    mock_llama.return_value.create_completion.assert_called_once_with(
+        prompt="Hi",
+        stream=True,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        repeat_penalty=config.repeat_penalty,
+        max_tokens=5,
+    )
+
+
+def test_missing_model_raises(tmp_path: Path) -> None:
+    config = LlmConfig(model_path=tmp_path / "missing.gguf")
+
+    with pytest.raises(FileNotFoundError):
+        create_llm_engine(config)

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -16,6 +16,7 @@ from voice_agent.asr import AsrEvent, create_asr_engine
 from voice_agent.audio import AudioIO
 from voice_agent.cli.visualizer import DotsVisualizer
 from voice_agent.config import ConfigManager
+from voice_agent.llm import LlmConfig as RuntimeLlmConfig, create_llm_engine
 from voice_agent.logging import configure_logging, get_logger
 from voice_agent.tts import KittenTTS, load_voice_inventory
 from voice_agent.vad import SileroVadError, SileroVadStream
@@ -141,6 +142,59 @@ def run(
                 typer.echo(f"Language confidence: {asr_confidence[-1]:.2f}")
 
     typer.echo("Loopback complete")
+
+
+@bench_app.command("llm")
+def bench_llm(
+    prompt: str = typer.Argument("Hello there", help="Prompt to send to the LLM"),
+    max_tokens: int = typer.Option(128, help="Maximum tokens to request from the backend"),
+    config_path: Optional[Path] = typer.Option(None, "--config-path", help="Override configuration path"),
+) -> None:
+    """Stream tokens from the configured llama.cpp backend."""
+
+    manager = _config_manager(config_path)
+    profile = manager.load().active()
+    runtime_config = RuntimeLlmConfig(
+        model_path=profile.llm.model_path,
+        temperature=profile.llm.temperature,
+        top_p=profile.llm.top_p,
+        repeat_penalty=profile.llm.repeat_penalty,
+        context_window=profile.llm.context_window,
+    )
+
+    try:
+        engine = create_llm_engine(runtime_config)
+    except FileNotFoundError as exc:
+        _LOG.error(
+            "[Continuous skepticism (Sherlock Protocol)] LLM model missing",
+            extra={
+                "classname": "CLI",
+                "function": "bench_llm",
+                "system_section": "llm",
+                "error": str(exc),
+                "structured_message": "Run voice-agent models pull to download",
+            },
+        )
+        raise typer.BadParameter(str(exc)) from exc
+
+    typer.echo("Streaming completion...\n")
+    try:
+        for chunk in engine.stream(prompt=prompt, max_tokens=max_tokens):
+            typer.echo(chunk, nl=False)
+    except RuntimeError as exc:
+        _LOG.error(
+            "[Continuous skepticism (Sherlock Protocol)] LLM streaming failed",
+            extra={
+                "classname": "CLI",
+                "function": "bench_llm",
+                "system_section": "llm",
+                "error": str(exc),
+                "structured_message": "Inspect llama.cpp configuration",
+            },
+        )
+        raise typer.Exit(code=1) from exc
+    else:
+        typer.echo("\n\nStream complete")
 
 
 @app.command("audio-devices")

--- a/voice_agent/llm/__init__.py
+++ b/voice_agent/llm/__init__.py
@@ -1,5 +1,6 @@
 """LLM inference helpers."""
 
 from .base import LlmConfig, LlmEngine
+from .llama_cpp import LlamaCppEngine, create_llm_engine
 
-__all__ = ["LlmConfig", "LlmEngine"]
+__all__ = ["LlmConfig", "LlmEngine", "LlamaCppEngine", "create_llm_engine"]

--- a/voice_agent/llm/base.py
+++ b/voice_agent/llm/base.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from pathlib import Path
+from typing import Iterable, Iterator
 
 
-@dataclass
+@dataclass(slots=True)
 class LlmConfig:
-    model_path: str
+    """Runtime configuration for an LLM engine."""
+
+    model_path: Path
     temperature: float = 0.7
     top_p: float = 0.9
     repeat_penalty: float = 1.1
@@ -18,5 +21,12 @@ class LlmConfig:
 class LlmEngine:
     """Base streaming LLM engine."""
 
-    def __iter__(self) -> Iterable[str]:
+    def stream(self, prompt: str, *, max_tokens: int | None = None) -> Iterable[str]:
+        """Yield text chunks produced by the model for *prompt*."""
+
         raise NotImplementedError
+
+    def __iter__(self) -> Iterator[str]:  # pragma: no cover - compatibility shim
+        raise NotImplementedError(
+            "Direct iteration is not supported; call stream(prompt=...) instead."
+        )

--- a/voice_agent/llm/llama_cpp.py
+++ b/voice_agent/llm/llama_cpp.py
@@ -1,0 +1,124 @@
+"""llama.cpp GGUF streaming inference runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover - import used for typing only
+    from llama_cpp import Llama
+
+from voice_agent.llm.base import LlmConfig, LlmEngine
+from voice_agent.logging import get_logger
+
+_LOG = get_logger(__name__)
+
+
+class LlamaCppEngine(LlmEngine):
+    """Wrapper around :mod:`llama_cpp` providing streaming completions."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        *,
+        n_threads: int | None = None,
+        n_gpu_layers: int | None = None,
+    ) -> None:
+        self._config = config
+        self._n_threads = n_threads
+        self._n_gpu_layers = n_gpu_layers
+        self._model = self._initialise_model()
+
+    def _initialise_model(self) -> "Llama":
+        model_path = self._config.model_path.expanduser()
+        if not model_path.exists():
+            _LOG.error(
+                "[Continuous skepticism (Sherlock Protocol)] Failed to load llama.cpp model",
+                extra={
+                    "classname": self.__class__.__name__,
+                    "function": "_initialise_model",
+                    "system_section": "llm",
+                    "error": f"Model missing at {model_path}",
+                    "structured_message": "Verify GGUF asset path",
+                },
+            )
+            raise FileNotFoundError(f"Model missing at {model_path}")
+
+        init_kwargs: Dict[str, object] = {
+            "model_path": str(model_path),
+            "n_ctx": self._config.context_window,
+        }
+        if self._n_threads is not None:
+            init_kwargs["n_threads"] = self._n_threads
+        if self._n_gpu_layers is not None:
+            init_kwargs["n_gpu_layers"] = self._n_gpu_layers
+
+        _LOG.info(
+            "Initialising llama.cpp",
+            extra={
+                "classname": self.__class__.__name__,
+                "function": "_initialise_model",
+                "system_section": "llm",
+                "structured_message": str({k: v for k, v in init_kwargs.items() if k != "model_path"}),
+            },
+        )
+        from llama_cpp import Llama
+
+        return Llama(**init_kwargs)
+
+    def stream(self, prompt: str, *, max_tokens: int | None = None) -> Iterable[str]:
+        sampling = {
+            "temperature": self._config.temperature,
+            "top_p": self._config.top_p,
+            "repeat_penalty": self._config.repeat_penalty,
+        }
+        if max_tokens is not None:
+            sampling["max_tokens"] = max_tokens
+
+        _LOG.info(
+            "Starting llama.cpp stream",
+            extra={
+                "classname": self.__class__.__name__,
+                "function": "stream",
+                "system_section": "llm",
+                "structured_message": str(sampling),
+            },
+        )
+
+        request_kwargs = {
+            "prompt": prompt,
+            "stream": True,
+            "temperature": self._config.temperature,
+            "top_p": self._config.top_p,
+            "repeat_penalty": self._config.repeat_penalty,
+        }
+        if max_tokens is not None:
+            request_kwargs["max_tokens"] = max_tokens
+
+        try:
+            iterator: Iterator[Dict[str, object]] = self._model.create_completion(**request_kwargs)
+        except Exception as exc:  # pragma: no cover - backend raises varying errors
+            _LOG.error(
+                "[Continuous skepticism (Sherlock Protocol)] llama.cpp completion failed",
+                extra={
+                    "classname": self.__class__.__name__,
+                    "function": "stream",
+                    "system_section": "llm",
+                    "error": str(exc),
+                    "structured_message": "Inspect llama.cpp backend logs",
+                },
+            )
+            raise RuntimeError("llama.cpp completion failed") from exc
+
+        for chunk in iterator:
+            choices = chunk.get("choices") if isinstance(chunk, dict) else None
+            if not choices:
+                continue
+            text = choices[0].get("text") if isinstance(choices[0], dict) else None
+            if text:
+                yield str(text)
+
+
+def create_llm_engine(config: LlmConfig) -> LlmEngine:
+    """Instantiate an :class:`LlamaCppEngine` for the provided config."""
+
+    return LlamaCppEngine(config)


### PR DESCRIPTION
## Summary
- add a llama.cpp-backed streaming engine with structured logging and exports
- expose a `bench llm` CLI command, docs update, and llama-cpp-python dependency
- cover the new runner with unit tests and mark the roadmap epic complete

## Testing
- poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e7015b7bcc832b81d6923d25171ad3