### PR TITLE
Add Smart-Turn orchestration, telemetry, and latency benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 - Kitten TTS integration with ONNXRuntime fallback, voice inventory tooling, and CLI preview playback.
 - Model fetcher with resumable downloads, bootstrap script for Linux/macOS, and placeholder benchmarking commands.
 - llama.cpp GGUF streaming runner with CLI streaming benchmark tooling.
+- Smart-Turn v2 orchestrator coordinating VAD, ASR, LLM, and TTS with structured telemetry spans.
+- Latency benchmarking suite covering audio loopback, ASR, LLM, and TTS backends with JSON output.
 
 ## Getting Started
 
@@ -48,7 +50,7 @@ Common commands:
 - `poetry run voice-agent tts sample --voice kitten/en_female_01 "Hello there"` — play a sample clip.
 - `poetry run voice-agent models pull tts/kitten-nano-0.2` — fetch Kitten TTS model assets.
 - `poetry run voice-agent bench llm "Hello"` — stream llama.cpp tokens for a quick sanity check.
-- `poetry run voice-agent bench latency` — measure loopback latency.
+- `poetry run voice-agent bench latency` — emit JSON latency metrics for audio, ASR, LLM, and TTS.
 
 ### Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Voice Agent Team <team@example.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 packages = [{ include = "voice_agent" }]
+include = ["voice_agent/config/default_config.toml"]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"
@@ -23,6 +24,9 @@ tomli-w = "^1.0.0"
 faster-whisper = { version = "^1.2.0", optional = true }
 mlx-whisper = { version = "^0.4.3", optional = true }
 llama-cpp-python = "^0.2.60"
+
+[tool.poetry.scripts]
+voice-agent = "voice_agent.__main__:main"
 
 [tool.poetry.extras]
 tts = ["onnxruntime"]

--- a/task.md
+++ b/task.md
@@ -9,6 +9,6 @@
 - [x] Implement Silero VAD streaming integration.
 - [x] Integrate MLX Whisper and Faster-Whisper ASR backends.
 - [x] Add llama.cpp GGUF streaming inference runner.
-- [ ] Implement Smart-Turn v2 orchestration and unit tests.
-- [ ] Build benchmarking tools for LLM, ASR, and TTS latency.
-- [ ] Extend packaging and telemetry features.
+- [x] Implement Smart-Turn v2 orchestration and unit tests.
+- [x] Build benchmarking tools for LLM, ASR, and TTS latency.
+- [x] Extend packaging and telemetry features.

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+
+from voice_agent.asr import AsrEngine
+from voice_agent.benchmarks import (
+    make_silence,
+    measure_asr_latency,
+    measure_llm_latency,
+    measure_tts_latency,
+)
+from voice_agent.llm import LlmEngine
+from voice_agent.telemetry import TelemetryClient
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._value = 0.0
+
+    def tick(self, step: float = 0.02) -> float:
+        self._value += step
+        return self._value
+
+
+class DummyAsr(AsrEngine):
+    def transcribe(self, audio_stream):  # type: ignore[override]
+        for _ in audio_stream:
+            pass
+
+
+class DummyLlm(LlmEngine):
+    def stream(self, prompt: str, *, max_tokens: int | None = None):  # type: ignore[override]
+        yield prompt
+        yield " done"
+
+
+class DummyTts:
+    def synthesize(self, text: str, chunk_config: dict[str, int]):
+        yield np.ones(10, dtype=np.float32)
+        yield np.ones(5, dtype=np.float32) * 0.5
+
+
+def test_measure_functions_emit_metrics() -> None:
+    clock = FakeClock()
+    telemetry = TelemetryClient(clock=lambda: clock.tick(0.01), time_source=lambda: clock.tick(0.001))
+
+    asr_result = measure_asr_latency(DummyAsr(), make_silence(0.1, 16000), clock=clock.tick, telemetry=telemetry)
+    assert asr_result.component == "asr"
+    assert asr_result.metrics["latency_ms"] > 0
+
+    llm_result = measure_llm_latency(DummyLlm(), "hi", max_tokens=4, clock=clock.tick, telemetry=telemetry)
+    assert llm_result.component == "llm"
+    assert llm_result.metrics["chunks"] == 2
+
+    tts_result = measure_tts_latency(DummyTts(), "hello", {}, clock=clock.tick, telemetry=telemetry)
+    assert tts_result.component == "tts"
+    assert tts_result.metrics["chunks"] == 2
+
+
+def test_make_silence_generates_bytes() -> None:
+    silence = list(make_silence(0.05, 16000))
+    assert len(silence) == 1
+    assert isinstance(silence[0], bytes)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
+import json
 from pathlib import Path
 from unittest import mock
+
+import numpy as np
 
 from typer.testing import CliRunner
 
@@ -30,3 +33,47 @@ def test_download_file_resume(tmp_path: Path) -> None:
 
     mock_get.assert_called_once()
     assert target.read_bytes() == b"helloworld"
+
+
+def test_bench_latency_outputs_metrics(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    ConfigManager(config_path=config_path)
+
+    class DummyAudio:
+        samplerate = 16000
+
+        def record_loopback(self, seconds: float, input_device=None, output_device=None):
+            return None
+
+    class DummyAsr:
+        def transcribe(self, audio_stream):
+            list(audio_stream)
+
+    class DummyLlm:
+        def stream(self, prompt: str, *, max_tokens: int | None = None):
+            yield "ok"
+
+    class DummyTts:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def synthesize(self, text: str, chunk_config):
+            yield np.ones(10, dtype=np.float32)
+
+    with (
+        mock.patch("voice_agent.cli.app.AudioIO", return_value=DummyAudio()),
+        mock.patch("voice_agent.cli.app.create_asr_engine", return_value=DummyAsr()),
+        mock.patch("voice_agent.cli.app.create_llm_engine", return_value=DummyLlm()),
+        mock.patch("voice_agent.cli.app.KittenTTS", DummyTts),
+    ):
+        result = runner.invoke(
+            app,
+            ["bench", "latency"],
+            env={"VOICE_AGENT_CONFIG": str(config_path)},
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert "audio_loopback_seconds" in payload
+    assert payload["asr"]["latency_ms"] >= 0
+    assert payload["llm"]["chunks"] == 1

--- a/tests/test_smart_turn.py
+++ b/tests/test_smart_turn.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from voice_agent.asr import AsrEngine, AsrEvent
+from voice_agent.config.models import TurnConfig, TtsConfig
+from voice_agent.llm import LlmEngine
+from voice_agent.runtime import SmartTurnError, SmartTurnOrchestrator
+from voice_agent.telemetry import TelemetryClient
+from voice_agent.vad import VadEvent, VadState
+
+
+class FakeAsr(AsrEngine):
+    def transcribe(self, audio_stream):  # type: ignore[override]
+        self.emit_partial(AsrEvent(text="hello", timestamp=0.05))
+        self.emit_final(AsrEvent(text="hello world", timestamp=0.2, confidence=0.92))
+
+
+class FakeLlm(LlmEngine):
+    def stream(self, prompt: str, *, max_tokens: int | None = None):  # type: ignore[override]
+        yield f"Response to {prompt}"
+
+
+class FakeTts:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, int]]] = []
+
+    def speak(self, text: str, chunk_config: dict[str, int]) -> None:
+        self.calls.append((text, chunk_config))
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._perf = 0.0
+        self._wall = 1000.0
+
+    def perf(self) -> float:
+        self._perf += 0.05
+        return self._perf
+
+    def wall(self) -> float:
+        self._wall += 1.0
+        return self._wall
+
+
+def _turn_config() -> TurnConfig:
+    return TurnConfig.model_validate(
+        {
+            "turn_min_utterance_ms": 50,
+            "turn_max_silence_ms": 600,
+            "turn_max_turn_ms": 2_000,
+            "turn_barge_in": True,
+        }
+    )
+
+
+def _tts_config(tmp_path: Path) -> TtsConfig:
+    return TtsConfig.model_validate(
+        {
+            "backend": "kitten",
+            "voice_id": "test",
+            "model_dir": str(tmp_path),
+            "chunk_min_chars": 10,
+            "chunk_min_ms": 100,
+            "chunk_max_gap_ms": 200,
+        }
+    )
+
+
+def test_smart_turn_success(tmp_path: Path) -> None:
+    frames = [
+        np.ones(1600, dtype=np.float32),
+        np.ones(1600, dtype=np.float32) * 0.5,
+    ]
+    vad_events = [
+        VadEvent(state=VadState.SPEECH, confidence=0.9, timestamp=0.05),
+        VadEvent(state=VadState.SILENCE, confidence=0.2, timestamp=0.2),
+    ]
+
+    fake_clock = FakeClock()
+    telemetry = TelemetryClient(clock=fake_clock.perf, time_source=fake_clock.wall)
+    tts = FakeTts()
+    orchestrator = SmartTurnOrchestrator(
+        asr_engine=FakeAsr(),
+        llm_engine=FakeLlm(),
+        tts_engine=tts,
+        turn_config=_turn_config(),
+        tts_config=_tts_config(tmp_path),
+        sample_rate=16000,
+        telemetry=telemetry,
+    )
+
+    result = orchestrator.run(frames, vad_events)
+
+    assert result.transcript == "hello world"
+    assert result.response == "Response to hello world"
+    assert result.utterance_ms == pytest.approx(150.0)
+    assert "asr.latency" in result.metrics
+    assert "llm.latency" in result.metrics
+    assert "tts.latency" in result.metrics
+    assert tts.calls and tts.calls[0][0] == "Response to hello world"
+
+
+def test_short_utterance_raises(tmp_path: Path) -> None:
+    frames = [np.ones(1600, dtype=np.float32)]
+    vad_events = [
+        VadEvent(state=VadState.SPEECH, confidence=0.9, timestamp=0.0),
+        VadEvent(state=VadState.SILENCE, confidence=0.1, timestamp=0.01),
+    ]
+
+    fake_clock = FakeClock()
+    telemetry = TelemetryClient(clock=fake_clock.perf, time_source=fake_clock.wall)
+    orchestrator = SmartTurnOrchestrator(
+        asr_engine=FakeAsr(),
+        llm_engine=FakeLlm(),
+        tts_engine=FakeTts(),
+        turn_config=_turn_config(),
+        tts_config=_tts_config(tmp_path),
+        sample_rate=16000,
+        telemetry=telemetry,
+    )
+
+    with pytest.raises(SmartTurnError):
+        orchestrator.run(frames, vad_events)

--- a/voice_agent/__main__.py
+++ b/voice_agent/__main__.py
@@ -1,4 +1,11 @@
 from voice_agent.cli.app import app
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Console entry point for the voice agent CLI."""
+
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/voice_agent/benchmarks/__init__.py
+++ b/voice_agent/benchmarks/__init__.py
@@ -1,0 +1,140 @@
+"""Latency benchmarking helpers for ASR, LLM, and TTS."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Iterator, Protocol
+
+import numpy as np
+
+from voice_agent.asr import AsrEngine
+from voice_agent.llm import LlmEngine
+from voice_agent.logging import get_logger
+from voice_agent.telemetry import TelemetryClient
+
+_LOG = get_logger(__name__)
+
+
+class TtsSynthesiser(Protocol):
+    def synthesize(self, text: str, chunk_config: Dict[str, int]) -> Iterable[np.ndarray]:
+        ...
+
+
+@dataclass
+class BenchmarkResult:
+    component: str
+    metrics: Dict[str, Any]
+
+
+def _emit_metrics(name: str, metrics: Dict[str, Any]) -> None:
+    _LOG.info(
+        "Benchmark metrics",
+        extra={
+            "classname": "Benchmark",
+            "function": name,
+            "system_section": "benchmark",
+            "structured_message": json.dumps(metrics, ensure_ascii=False),
+        },
+    )
+
+
+def measure_asr_latency(
+    engine: AsrEngine,
+    audio_stream: Iterable[bytes],
+    *,
+    clock: Callable[[], float] | None = None,
+    telemetry: TelemetryClient | None = None,
+) -> BenchmarkResult:
+    timer = clock or time.perf_counter
+    start = timer()
+    engine.transcribe(audio_stream)
+    end = timer()
+    latency_ms = (end - start) * 1000.0
+    metrics = {"latency_ms": latency_ms}
+    if telemetry:
+        telemetry.emit("asr.benchmark", **metrics)
+    _emit_metrics("measure_asr_latency", metrics)
+    return BenchmarkResult(component="asr", metrics=metrics)
+
+
+def measure_llm_latency(
+    engine: LlmEngine,
+    prompt: str,
+    *,
+    max_tokens: int = 128,
+    clock: Callable[[], float] | None = None,
+    telemetry: TelemetryClient | None = None,
+) -> BenchmarkResult:
+    timer = clock or time.perf_counter
+    start = timer()
+    first_token_ms: float | None = None
+    chunk_count = 0
+    char_count = 0
+    for chunk in engine.stream(prompt=prompt, max_tokens=max_tokens):
+        now = timer()
+        if first_token_ms is None:
+            first_token_ms = (now - start) * 1000.0
+        chunk_count += 1
+        char_count += len(chunk)
+    total_ms = (timer() - start) * 1000.0
+    metrics = {
+        "total_ms": total_ms,
+        "time_to_first_chunk_ms": first_token_ms or total_ms,
+        "chunks": chunk_count,
+        "characters": char_count,
+    }
+    if telemetry:
+        telemetry.emit("llm.benchmark", **metrics)
+    _emit_metrics("measure_llm_latency", metrics)
+    return BenchmarkResult(component="llm", metrics=metrics)
+
+
+def measure_tts_latency(
+    synthesiser: TtsSynthesiser,
+    text: str,
+    chunk_config: Dict[str, int],
+    *,
+    clock: Callable[[], float] | None = None,
+    telemetry: TelemetryClient | None = None,
+) -> BenchmarkResult:
+    timer = clock or time.perf_counter
+    start = timer()
+    first_chunk_ms: float | None = None
+    chunk_count = 0
+    sample_count = 0
+    for chunk in synthesiser.synthesize(text, chunk_config):
+        now = timer()
+        if first_chunk_ms is None:
+            first_chunk_ms = (now - start) * 1000.0
+        chunk_count += 1
+        if isinstance(chunk, np.ndarray):
+            sample_count += int(chunk.size)
+    total_ms = (timer() - start) * 1000.0
+    metrics = {
+        "total_ms": total_ms,
+        "time_to_first_chunk_ms": first_chunk_ms or total_ms,
+        "chunks": chunk_count,
+        "samples": sample_count,
+    }
+    if telemetry:
+        telemetry.emit("tts.benchmark", **metrics)
+    _emit_metrics("measure_tts_latency", metrics)
+    return BenchmarkResult(component="tts", metrics=metrics)
+
+
+def make_silence(duration_s: float, sample_rate: int) -> Iterator[bytes]:
+    frames = int(duration_s * sample_rate)
+    chunk = np.zeros(frames, dtype=np.float32)
+    yield chunk.tobytes()
+
+
+__all__ = [
+    "BenchmarkResult",
+    "measure_asr_latency",
+    "measure_llm_latency",
+    "measure_tts_latency",
+    "make_silence",
+]
+

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -6,18 +6,25 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 import requests
 import typer
 
+from voice_agent.benchmarks import (
+    make_silence,
+    measure_asr_latency,
+    measure_llm_latency,
+    measure_tts_latency,
+)
 from voice_agent.asr import AsrEvent, create_asr_engine
 from voice_agent.audio import AudioIO
 from voice_agent.cli.visualizer import DotsVisualizer
 from voice_agent.config import ConfigManager
 from voice_agent.llm import LlmConfig as RuntimeLlmConfig, create_llm_engine
 from voice_agent.logging import configure_logging, get_logger
+from voice_agent.telemetry import TelemetryClient
 from voice_agent.tts import KittenTTS, load_voice_inventory
 from voice_agent.vad import SileroVadError, SileroVadStream
 
@@ -306,15 +313,87 @@ def models_pull(
 def bench_latency(
     config_path: Optional[Path] = typer.Option(None, "--config-path", help="Override configuration path"),
 ) -> None:
-    """Run a lightweight latency probe for audio loopback."""
+    """Run latency probes for audio loopback, ASR, LLM, and TTS."""
 
     manager = _config_manager(config_path)
-    manager.load()
+    config = manager.load()
+    profile = config.active()
+    telemetry = TelemetryClient()
+    metrics: Dict[str, object] = {}
+
     audio = AudioIO(samplerate=16000)
     start = time.perf_counter()
     audio.record_loopback(seconds=1.0)
-    duration = time.perf_counter() - start
-    typer.echo(json.dumps({"loopback_seconds": duration}, indent=2))
+    metrics["audio_loopback_seconds"] = time.perf_counter() - start
+
+    try:
+        asr_engine = create_asr_engine(profile.asr)
+    except Exception as exc:  # pragma: no cover - backend optional
+        _LOG.error(
+            "ASR benchmark setup failed",
+            extra={
+                "classname": "CLI",
+                "function": "bench_latency",
+                "system_section": "asr",
+                "error": str(exc),
+                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise ASR backend",
+            },
+        )
+        metrics["asr"] = {"error": str(exc)}
+    else:
+        asr_result = measure_asr_latency(asr_engine, make_silence(1.0, audio.samplerate), telemetry=telemetry)
+        metrics["asr"] = asr_result.metrics
+
+    runtime_config = RuntimeLlmConfig(
+        model_path=profile.llm.model_path,
+        temperature=profile.llm.temperature,
+        top_p=profile.llm.top_p,
+        repeat_penalty=profile.llm.repeat_penalty,
+        context_window=profile.llm.context_window,
+    )
+
+    try:
+        llm_engine = create_llm_engine(runtime_config)
+    except Exception as exc:  # pragma: no cover - backend optional
+        _LOG.error(
+            "LLM benchmark setup failed",
+            extra={
+                "classname": "CLI",
+                "function": "bench_latency",
+                "system_section": "llm",
+                "error": str(exc),
+                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise LLM backend",
+            },
+        )
+        metrics["llm"] = {"error": str(exc)}
+    else:
+        llm_result = measure_llm_latency(llm_engine, "Benchmark prompt", max_tokens=32, telemetry=telemetry)
+        metrics["llm"] = llm_result.metrics
+
+    try:
+        tts_engine = KittenTTS(profile.tts.model_dir, profile.tts.voice_id)
+    except Exception as exc:  # pragma: no cover - backend optional
+        _LOG.error(
+            "TTS benchmark setup failed",
+            extra={
+                "classname": "CLI",
+                "function": "bench_latency",
+                "system_section": "tts",
+                "error": str(exc),
+                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise TTS backend",
+            },
+        )
+        metrics["tts"] = {"error": str(exc)}
+    else:
+        chunk_cfg = {
+            "chunk_min_chars": profile.tts.chunk_min_chars,
+            "chunk_min_ms": profile.tts.chunk_min_ms,
+            "chunk_max_gap_ms": profile.tts.chunk_max_gap_ms,
+        }
+        tts_result = measure_tts_latency(tts_engine, "Benchmarking latency", chunk_cfg, telemetry=telemetry)
+        metrics["tts"] = tts_result.metrics
+
+    typer.echo(json.dumps(metrics, indent=2, sort_keys=True))
 
 
 def _download_file(url: str, target: Path) -> None:

--- a/voice_agent/runtime/__init__.py
+++ b/voice_agent/runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime orchestration utilities."""
+
+from .smart_turn import SmartTurnError, SmartTurnOrchestrator, SmartTurnResult
+
+__all__ = ["SmartTurnOrchestrator", "SmartTurnResult", "SmartTurnError"]
+

--- a/voice_agent/runtime/smart_turn.py
+++ b/voice_agent/runtime/smart_turn.py
@@ -1,0 +1,214 @@
+"""Smart-Turn v2 orchestration for coordinating ASR, LLM, and TTS."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, List, Protocol, Sequence
+
+import numpy as np
+
+from voice_agent.asr import AsrEngine, AsrEvent
+from voice_agent.config.models import TurnConfig, TtsConfig
+from voice_agent.llm import LlmEngine
+from voice_agent.logging import get_logger
+from voice_agent.telemetry import TelemetryClient
+from voice_agent.vad import VadEvent, VadState
+
+
+class TtsEngine(Protocol):
+    """Protocol for the subset of TTS behaviour required by the orchestrator."""
+
+    def speak(self, text: str, chunk_config: Dict[str, int]) -> None:  # pragma: no cover - interface
+        ...
+
+
+@dataclass(slots=True)
+class SmartTurnResult:
+    """Captures the results of a Smart-Turn conversation cycle."""
+
+    transcript: str
+    response: str
+    partials: Sequence[str]
+    confidences: Sequence[float]
+    utterance_ms: float
+    metrics: Dict[str, float] = field(default_factory=dict)
+
+
+class SmartTurnError(RuntimeError):
+    """Raised when the Smart-Turn orchestration fails."""
+
+
+class SmartTurnOrchestrator:
+    """Coordinate audio VAD, ASR transcription, LLM completion, and TTS playback."""
+
+    def __init__(
+        self,
+        *,
+        asr_engine: AsrEngine,
+        llm_engine: LlmEngine,
+        tts_engine: TtsEngine,
+        turn_config: TurnConfig,
+        tts_config: TtsConfig,
+        sample_rate: int,
+        telemetry: TelemetryClient | None = None,
+    ) -> None:
+        self._asr = asr_engine
+        self._llm = llm_engine
+        self._tts = tts_engine
+        self._turn = turn_config
+        self._tts_config = tts_config
+        self._sample_rate = sample_rate
+        self._telemetry = telemetry or TelemetryClient()
+        self._logger = get_logger(f"{__name__}.SmartTurnOrchestrator")
+        self._tts_active = False
+
+    def run(
+        self,
+        audio_frames: Iterable[np.ndarray],
+        vad_stream: Iterable[VadEvent],
+    ) -> SmartTurnResult:
+        """Execute a single Smart-Turn conversation cycle."""
+
+        if self._tts_active and not self._turn.barge_in:
+            raise SmartTurnError("Barge-in disabled while synthesiser is active")
+
+        start_index = len(self._telemetry.events)
+        captured: List[np.ndarray] = []
+        partials: List[str] = []
+        finals: List[AsrEvent] = []
+        confidences: List[float] = []
+
+        speech_started = False
+        speech_start_ts: float | None = None
+        speech_end_ts: float | None = None
+        processed_seconds = 0.0
+        vad_iter = iter(vad_stream)
+        next_event = self._advance_event(vad_iter)
+
+        for chunk in audio_frames:
+            frame = np.ascontiguousarray(chunk, dtype=np.float32).reshape(-1)
+            chunk_seconds = frame.size / float(self._sample_rate)
+            chunk_end = processed_seconds + chunk_seconds
+            started_in_chunk = False
+
+            while next_event and next_event.timestamp <= chunk_end + 1e-6:
+                if next_event.state is VadState.SPEECH:
+                    if not speech_started:
+                        speech_start_ts = next_event.timestamp
+                        speech_started = True
+                        started_in_chunk = True
+                        self._logger.info(
+                            "Detected speech onset",
+                            extra={
+                                "classname": self.__class__.__name__,
+                                "function": "run",
+                                "system_section": "smart_turn",
+                                "structured_message": json.dumps({"timestamp": speech_start_ts}),
+                            },
+                        )
+                elif next_event.state is VadState.SILENCE and speech_started:
+                    speech_end_ts = next_event.timestamp
+                    speech_started = False
+                    self._logger.info(
+                        "Detected speech offset",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "run",
+                            "system_section": "smart_turn",
+                            "structured_message": json.dumps({"timestamp": speech_end_ts}),
+                        },
+                    )
+                    break
+                next_event = self._advance_event(vad_iter)
+
+            if speech_started or started_in_chunk:
+                captured.append(frame.copy())
+
+            processed_seconds = chunk_end
+            if speech_end_ts is not None and not speech_started:
+                break
+
+            if speech_start_ts is not None:
+                elapsed_ms = (processed_seconds - speech_start_ts) * 1000.0
+                if elapsed_ms >= self._turn.max_turn_ms:
+                    self._logger.warning(
+                        "Turn exceeded maximum duration",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "run",
+                            "system_section": "smart_turn",
+                            "structured_message": json.dumps({"elapsed_ms": elapsed_ms}),
+                        },
+                    )
+                    speech_end_ts = processed_seconds
+                    break
+
+        if not captured or speech_start_ts is None:
+            raise SmartTurnError("No utterance detected")
+
+        if speech_end_ts is None:
+            speech_end_ts = processed_seconds
+
+        utterance_ms = max(0.0, (speech_end_ts - speech_start_ts) * 1000.0)
+        if utterance_ms < float(self._turn.min_utterance_ms):
+            raise SmartTurnError("Utterance shorter than minimum duration")
+
+        audio_payload = [frame.tobytes() for frame in captured]
+        metrics: Dict[str, float] = {"utterance_ms": utterance_ms}
+
+        def _on_partial(event: AsrEvent) -> None:
+            partials.append(event.text)
+
+        def _on_final(event: AsrEvent) -> None:
+            finals.append(event)
+
+        def _on_confidence(value: float) -> None:
+            confidences.append(value)
+
+        self._asr.on_partial(_on_partial)
+        self._asr.on_final(_on_final)
+        self._asr.on_confidence(_on_confidence)
+
+        with self._telemetry.span("asr.latency"):
+            self._asr.transcribe(audio_payload)
+
+        if not finals:
+            raise SmartTurnError("ASR produced no final transcript")
+
+        transcript = finals[-1].text
+
+        with self._telemetry.span("llm.latency"):
+            response = "".join(self._llm.stream(prompt=transcript))
+
+        self._tts_active = True
+        try:
+            with self._telemetry.span("tts.latency"):
+                self._tts.speak(response, {
+                    "chunk_min_chars": self._tts_config.chunk_min_chars,
+                    "chunk_min_ms": self._tts_config.chunk_min_ms,
+                    "chunk_max_gap_ms": self._tts_config.chunk_max_gap_ms,
+                })
+        finally:
+            self._tts_active = False
+
+        for event in self._telemetry.events[start_index:]:
+            if event.name.endswith("latency") and "duration_ms" in event.fields:
+                metrics[event.name] = float(event.fields["duration_ms"])
+
+        return SmartTurnResult(
+            transcript=transcript,
+            response=response,
+            partials=tuple(partials),
+            confidences=tuple(confidences),
+            utterance_ms=utterance_ms,
+            metrics=metrics,
+        )
+
+    @staticmethod
+    def _advance_event(events: Iterator[VadEvent]) -> VadEvent | None:
+        try:
+            return next(events)
+        except StopIteration:
+            return None
+

--- a/voice_agent/telemetry/__init__.py
+++ b/voice_agent/telemetry/__init__.py
@@ -1,0 +1,73 @@
+"""Telemetry helpers for emitting structured latency events."""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, List
+
+from voice_agent.logging import get_logger
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Represents a telemetry datapoint recorded by the runtime."""
+
+    name: str
+    timestamp: float
+    fields: Dict[str, Any]
+
+
+class TelemetryClient:
+    """Collect and emit telemetry events to the structured logger."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] | None = None,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        self._clock = clock or time.perf_counter
+        self._time_source = time_source or time.time
+        self._logger = get_logger(f"{__name__}.TelemetryClient")
+        self._events: List[TelemetryEvent] = []
+
+    def emit(self, name: str, **fields: Any) -> TelemetryEvent:
+        """Emit a telemetry event and record it for later inspection."""
+
+        event = TelemetryEvent(name=name, timestamp=self._time_source(), fields=dict(fields))
+        self._events.append(event)
+        payload = {"name": name, **fields}
+        self._logger.info(
+            "Telemetry event",
+            extra={
+                "classname": self.__class__.__name__,
+                "function": "emit",
+                "system_section": "telemetry",
+                "structured_message": json.dumps(payload, ensure_ascii=False),
+            },
+        )
+        return event
+
+    @contextmanager
+    def span(self, name: str, **fields: Any) -> Iterator[None]:
+        """Measure the duration of a block and emit it as telemetry."""
+
+        start = self._clock()
+        try:
+            yield
+        finally:
+            duration_ms = (self._clock() - start) * 1000.0
+            self.emit(name, duration_ms=duration_ms, **fields)
+
+    @property
+    def events(self) -> List[TelemetryEvent]:
+        """Return a copy of emitted telemetry events."""
+
+        return list(self._events)
+
+
+__all__ = ["TelemetryClient", "TelemetryEvent"]
+


### PR DESCRIPTION
## Summary
- add a Smart-Turn v2 orchestrator that coordinates VAD, ASR, LLM, and TTS with telemetry reporting
- introduce reusable telemetry and benchmarking helpers and wire them into the CLI latency command
- extend packaging/docs to expose the CLI entry point and document the new latency tooling

## Testing
- poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e7eb4e580c832bbe78bd1d507f774a