### PR TITLE
Handle positional destinations for models pull CLI

### DIFF
--- a/task.md
+++ b/task.md
@@ -14,3 +14,4 @@
 - [x] Extend packaging and telemetry features.
 - [x] Add platform-specific start build scripts with validation and packaging.
 - [x] Document the start build workflow in project docs.
+- [x] Improve `voice-agent models pull` destination handling for Typer 0.9 compatibility.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,3 +77,62 @@ def test_bench_latency_outputs_metrics(tmp_path: Path) -> None:
     assert "audio_loopback_seconds" in payload
     assert payload["asr"]["latency_ms"] >= 0
     assert payload["llm"]["chunks"] == 1
+
+
+def test_models_pull_accepts_positional_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "models"
+
+    with mock.patch("voice_agent.cli.app._download_file") as mock_download:
+        mock_download.side_effect = lambda url, target: target.write_text("ok")
+        result = runner.invoke(
+            app,
+            ["models", "pull", "tts/kitten-nano-0.2", str(destination)],
+        )
+
+    assert result.exit_code == 0
+    expected_files = {destination / "kitten_tts_nano_v0_2.onnx", destination / "voices.npz", destination / "config.json"}
+    actual_files = {call.args[1] for call in mock_download.call_args_list}
+    assert actual_files == expected_files
+
+
+def test_models_pull_accepts_option_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "from-option"
+
+    with mock.patch("voice_agent.cli.app._download_file") as mock_download:
+        result = runner.invoke(
+            app,
+            ["models", "pull", "tts/kitten-nano-0.2", "--dest", str(destination)],
+        )
+
+    assert result.exit_code == 0
+    assert {call.args[1] for call in mock_download.call_args_list} == {
+        destination / "kitten_tts_nano_v0_2.onnx",
+        destination / "voices.npz",
+        destination / "config.json",
+    }
+
+
+def test_models_pull_prefers_option_destination_when_both_provided(tmp_path: Path) -> None:
+    positional = tmp_path / "positional"
+    option = tmp_path / "option"
+
+    with mock.patch("voice_agent.cli.app._download_file") as mock_download:
+        result = runner.invoke(
+            app,
+            [
+                "models",
+                "pull",
+                "tts/kitten-nano-0.2",
+                str(positional),
+                "--dest",
+                str(option),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Warning: Positional destination ignored because --dest was provided" in result.stderr
+    assert {call.args[1] for call in mock_download.call_args_list} == {
+        option / "kitten_tts_nano_v0_2.onnx",
+        option / "voices.npz",
+        option / "config.json",
+    }

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -277,12 +278,90 @@ def tts_sample(
     })
 
 
-@models_app.command("pull")
+DEFAULT_MODEL_DIR = Path.home() / ".voice-agent" / "models"
+
+
+@models_app.command(
+    "pull",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def models_pull(
+    ctx: typer.Context,
     model_id: str = typer.Argument(..., help="Model identifier to download"),
-    destination: Path = typer.Option(Path.home() / ".voice-agent" / "models", "--dest", help="Download directory"),
 ) -> None:
     """Download model assets with resume and checksum validation (simplified)."""
+
+    extra_args = list(ctx.args)
+    positional_destinations: list[Path] = []
+    option_destination: Optional[Path] = None
+
+    idx = 0
+    while idx < len(extra_args):
+        token = extra_args[idx]
+        if token in {"--dest", "-d"}:
+            if idx + 1 >= len(extra_args):
+                typer.echo("Error: --dest requires a value.", err=True)
+                raise typer.Exit(code=2)
+            option_destination = Path(extra_args[idx + 1])
+            idx += 2
+            continue
+        if token.startswith("--dest="):
+            option_destination = Path(token.split("=", 1)[1])
+            idx += 1
+            continue
+        if token.startswith("-d") and token not in {"-d"}:
+            option_destination = Path(token[2:])
+            idx += 1
+            continue
+        positional_destinations.append(Path(token))
+        idx += 1
+
+    destination = (
+        option_destination
+        or (positional_destinations[0] if positional_destinations else DEFAULT_MODEL_DIR)
+    )
+
+    if len(positional_destinations) > 1:
+        _LOG.warning(
+            "Multiple positional destinations provided",
+            extra={
+                "log_filename": __file__,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "classname": "CLI",
+                "function": "models_pull",
+                "system_section": "models",
+                "line_num": 0,
+                "error": None,
+                "db_phase": "none",
+                "method": "NONE",
+                "log_message": "[Continuous skepticism (Sherlock Protocol)] Only the first positional destination will be used",
+            },
+        )
+        typer.echo(
+            "Warning: Multiple positional destinations provided; only the first will be used.",
+            err=True,
+        )
+
+    if option_destination and positional_destinations:
+        _LOG.warning(
+            "Conflicting destination overrides provided",
+            extra={
+                "log_filename": __file__,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "classname": "CLI",
+                "function": "models_pull",
+                "system_section": "models",
+                "line_num": 0,
+                "error": None,
+                "db_phase": "none",
+                "method": "NONE",
+                "log_message": "[Continuous skepticism (Sherlock Protocol)] Positional destination ignored in favour of --dest",
+            },
+        )
+        typer.echo(
+            "Warning: Positional destination ignored because --dest was provided; using --dest value.",
+            err=True,
+        )
 
     MODEL_MAP = {
         "tts/kitten-nano-0.2": [


### PR DESCRIPTION
## Summary
- allow `voice-agent models pull` to accept positional destination overrides while keeping support for `--dest`
- log and warn when conflicting or multiple destinations are provided and centralize the default models directory path
- add CLI regression tests for positional, option, and mixed destination usage and document the completed task

## Testing
- poetry run ruff check
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed548d8c44832bae5ae45c7d7a3481