### PR TITLE
Pin Click dependency for Typer help compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -24,6 +24,53 @@ files = [
     {file = "av-16.0.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:c69a228c95422391e527b0fe98d4ce632b4ac1045a1c16bf5a308ea23d9e5fe8"},
     {file = "av-16.0.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:26491d71419d967914855be05da78bf20dfb58e7f3157723056c692e33527e7d"},
     {file = "av-16.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:18c457355b8d116d613440380c38097923e1a53ce51e7d2c37a49e58a3fd7614"},
+    {file = "av-16.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:28b700d1a5b1261ae0d66a4b9a30685bf22f3cc0c35d5b33f9bfe84d2caff1c5"},
+    {file = "av-16.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:eceffc239842da23a202be5bb7133a94b35c64a989124d30d849c6f56ec6a00f"},
+    {file = "av-16.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:561dde9a7f9ce35e2f169685eb90f6990519f0247e6c440e901d39e71ad7a126"},
+    {file = "av-16.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:88999666359eb8d34452ee21f3c4dc66d3ce5e0e465cadad5c200e6ae4044266"},
+    {file = "av-16.0.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:8fa6539642777631dfcedf1df3bec08fbb61850df3f8abdbd5fda2a19c3a5fb9"},
+    {file = "av-16.0.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ecf207dfccae8da08dfbe286a6f0265cfcf11b4547a41d56795f1c071cf2da50"},
+    {file = "av-16.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6954d8d9fd21f9a9f38f5376cf622223b8cd9c883520e2fdf7cde95a58bcc652"},
+    {file = "av-16.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2683a755eb6a41a7847aea316c03f652b9b68560302f375b692d716c9c2860e"},
+    {file = "av-16.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:51e450b143b36b2935a5dc315d6c05c8cf9e16efe010dcb31e79d70b562c7735"},
+    {file = "av-16.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:78ba78f37ba87c8d3748679a1eb76fe3d052696440f6f9b1a587b0a9dff1f9c0"},
+    {file = "av-16.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:ec85a19663ddc165ff86f2405db2be2f1b77f830ee25e9a4280f11b1be8753ea"},
+    {file = "av-16.0.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:db246027eb256730d54ee1b511d61fa768935d8baabef84d8799d13aa87f6b2f"},
+    {file = "av-16.0.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:396c6aefb7d7880202a88c899809919f83f070a0afa4531d3479139d0256284f"},
+    {file = "av-16.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:521da5bf1b4ffcfb312c9a77c63b1178a7967760ca4f88d755b7adf75267538e"},
+    {file = "av-16.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:04c6450de1b276f21b580282f3b65b66c33eec7cb90dcb2e8a6d3e4a79b531d6"},
+    {file = "av-16.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec876ba99380eabaef86ac1c964262cfce17793d3bee83f7d802fdc4a11f881f"},
+    {file = "av-16.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff5f0952bedc61933ea7825a836beced235d2d9728dc641f8172ef0a3e4457a8"},
+    {file = "av-16.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:0981712d96eafd80e6ca0c209491077b70948971656b9ff4c9cefba4c498b051"},
+    {file = "av-16.0.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:2a97de9b86b727e75dcf34cbb7f2cb27bd4f20fa0f1e140fca04e039d7b4270f"},
+    {file = "av-16.0.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:61e06cffe51358992633bfaf7d10b486d65d13096a9049225ca56c43f3999a0b"},
+    {file = "av-16.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ac317897e9ba520f9045a82a4740926144b37a19caa5f80964dbe76bea7cf870"},
+    {file = "av-16.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ba5389c1bdcac049115cfc43de126e141308a00b77010599888cdb160a77a51d"},
+    {file = "av-16.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:62166854fd438bc82032a200b93f3c0886c37be414f6a2e62aa8b2c764ea941e"},
+    {file = "av-16.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5ed9cd21f8fcf766f0a7c6b0f1c76dbc7d16b63243f0a92f69bdd6bae4d9e89e"},
+    {file = "av-16.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:5172a6f6d9ec16d3cfc815cd58204f4be52d768f50fc67f987a0f221cc8e89fc"},
+    {file = "av-16.0.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:df8a5af0a670007954cbdf0a515d8181c9839ced6391f68eb278c1eb6cbec804"},
+    {file = "av-16.0.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:336528ecf5bd0916bfe31090e9b99ffe60c62f7d53719508329e67d2b9d91d50"},
+    {file = "av-16.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:544aeeef74c16665c4268cf421dd3aeae0512d90991574a5b2f4fad63ea0f3d4"},
+    {file = "av-16.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a521ef3e3b079bd7d40c66501b7c7c89723263f1c3c659be21468adfb833024c"},
+    {file = "av-16.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:92c2676c68c88ea9e13d5f034d48f080ad0cdc9c0be999838995a0f291a59b5c"},
+    {file = "av-16.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:afef5953aeeaf1eb820c01b550298409d15b2d1b5fc9975c54c67981b3d2ca7d"},
+    {file = "av-16.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:310f8aceeadee5d9f7b22032dd1e8f33602cec9b743deb8fe8401d597cc32f7d"},
+    {file = "av-16.0.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:d6b6d45aa209a1266f9cf196fccd8bec6fb141fce58c465c3469ec0ea88be4dd"},
+    {file = "av-16.0.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d6ec03e1c88065058b5c94fed1bd0c984283e8d3c78195c02bde8ec845f00026"},
+    {file = "av-16.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c959e73af93553e3b4ec90258424c777d76f00b548d42d6aa0cb86cc5c524f36"},
+    {file = "av-16.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:949960404a25451f26797d929f88ffb88a1115d8fd8d664a655ac597bec555aa"},
+    {file = "av-16.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:af935b1fceb2fc93310421538c629ccad55f241c1bb2e883614713a68f094d46"},
+    {file = "av-16.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5dca4eda72164eb1515f6a4f328a0af2f9d5e4bfa94be1707661f97cbe7d7990"},
+    {file = "av-16.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:3a995347f2215a9fa25f686bb7f7ce310f3cbbc259ba3930d6a9312b9958ecde"},
+    {file = "av-16.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:072f49aa0bcc99181baba3d85d367c02f4900032e3ad75930e3b357957113700"},
+    {file = "av-16.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:6a86815f9c78cb89cdc2be48782a4cc773ad57cd44eedd912c313bfba776af15"},
+    {file = "av-16.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e3c47c29eb5e5007961ff470aa1ca1504c86cf91e4fe78be5f03b64d45780f02"},
+    {file = "av-16.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:f5e6021a7b4ea3c5d0560ae48799337ca80074f02210270be63144bb68b0a8e0"},
+    {file = "av-16.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83e53b798972ad2592738287f0a60754ee5827afb9b534cd79ed8f7f88ccb66d"},
+    {file = "av-16.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1c1996564f80bdecd98379a6b1d26302756c426f6d5c1931fd6f8c69469aa010"},
+    {file = "av-16.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8d1fb7292cb5f6ac1033a4631929fe1293e9cd96a15756346fb66143f5fee922"},
+    {file = "av-16.0.0.tar.gz", hash = "sha256:c275830f9ad575a2da941177b81d11b442271d205ddb5cd27fa82930aa69b38e"},
 ]
 
 [[package]]
@@ -226,14 +273,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"},
-    {file = "click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"},
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
 ]
 
 [package.dependencies]
@@ -2257,4 +2304,4 @@ tts = ["onnxruntime"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "59037106180c1745d4f5a066d7812d0d890d438c5f27960876b41e2c172a7d51"
+content-hash = "c1b4cca88abb2109acd43785097f5f5af23e3fd6eb8d4a1d360c429b5e3467e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requests = "^2.31.0"
 pydantic = "^2.7.0"
 platformdirs = "^4.2.0"
 rich = "^13.7.0"
+click = ">=8.1,<8.2"
 onnxruntime = { version = "^1.17.0", optional = true }
 pyaudio = { version = "^0.2.14", optional = true }
 scipy = "^1.12.0"

--- a/task.md
+++ b/task.md
@@ -15,3 +15,4 @@
 - [x] Add platform-specific start build scripts with validation and packaging.
 - [x] Document the start build workflow in project docs.
 - [x] Improve `voice-agent models pull` destination handling for Typer 0.9 compatibility.
+- [x] Pin Click dependency to <8.2 to restore CLI help output.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 from voice_agent.cli.app import _download_file, app
 from voice_agent.config import ConfigManager
 
-runner = CliRunner()
+runner = CliRunner(mix_stderr=False)
 
 
 def test_profile_list(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- constrain Click to <8.2 and refresh the lockfile so Typer help output works again
- adjust CLI tests to capture stderr separately under the downgraded Click version
- record the dependency pin in the task tracker

## Testing
- poetry run voice-agent --help
- poetry run ruff check .
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed609b5a08832bad555ad396145d7a