### PR TITLE
Fix CLI VAD fallback logging and add regression coverage

### DIFF
--- a/task.md
+++ b/task.md
@@ -16,3 +16,6 @@
 - [x] Document the start build workflow in project docs.
 - [x] Improve `voice-agent models pull` destination handling for Typer 0.9 compatibility.
 - [x] Pin Click dependency to <8.2 to restore CLI help output.
+- [x] Prevent CLI VAD fallback logging from overwriting reserved LogRecord fields.
+- [x] Emit derived Sherlock prompt lines from the structured formatter output.
+- [x] Add regression coverage for CLI run VAD fallback and structured logging output.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 from voice_agent.cli.app import _download_file, app
 from voice_agent.config import ConfigManager
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def test_profile_list(tmp_path: Path) -> None:
@@ -136,3 +136,33 @@ def test_models_pull_prefers_option_destination_when_both_provided(tmp_path: Pat
         option / "voices.npz",
         option / "config.json",
     }
+
+
+def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    ConfigManager(config_path=config_path)
+
+    class DummyAudio:
+        samplerate = 16000
+
+        def record_loopback(self, seconds: float, input_device=None, output_device=None):
+            return np.zeros((160, 1), dtype=np.float32)
+
+    with (
+        mock.patch("voice_agent.cli.app.AudioIO", return_value=DummyAudio()),
+        mock.patch(
+            "voice_agent.cli.app.SileroVadStream.from_numpy",
+            side_effect=FileNotFoundError("missing model"),
+        ),
+        mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
+        mock.patch("voice_agent.cli.app.create_asr_engine", side_effect=RuntimeError("asr disabled")),
+    ):
+        result = runner.invoke(
+            app,
+            ["run"],
+            env={"VOICE_AGENT_CONFIG": str(config_path)},
+        )
+
+    assert result.exit_code == 0
+    assert "Loopback complete" in result.stdout
+    assert mock_visualizer.return_value.run_demo.called

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,32 @@
+import json
+import logging
+
+from voice_agent.logging import SHERLOCK_PROMPT, StructuredFormatter
+
+
+def test_structured_formatter_emits_derived_message() -> None:
+    record = logging.LogRecord(
+        name="voice_agent.tests",
+        level=logging.INFO,
+        pathname="/tmp/test.py",
+        lineno=42,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    record.classname = "TestCase"
+    record.function = "test_structured_formatter_emits_derived_message"
+    record.system_section = "logging"
+    record.derived_message = "[Continuous skepticism (Sherlock Protocol)] Test derived line"
+
+    formatter = StructuredFormatter()
+    formatted = formatter.format(record)
+    lines = formatted.splitlines()
+
+    assert len(lines) == 7
+    payload = json.loads(lines[0])
+    assert payload["message"] == "hello"
+    assert payload["derived_message"] == record.derived_message
+    assert lines[1] == record.derived_message
+    prompt_lines = SHERLOCK_PROMPT.splitlines()
+    assert lines[2:] == prompt_lines

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -87,7 +87,7 @@ def run(
                 "function": "run",
                 "system_section": "vad",
                 "error": str(exc),
-                "message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
             },
         )
         visualizer.run_demo(data)
@@ -99,7 +99,7 @@ def run(
                 "function": "run",
                 "system_section": "vad",
                 "error": str(exc),
-                "message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
             },
         )
         visualizer.run_demo(data)

--- a/voice_agent/logging/__init__.py
+++ b/voice_agent/logging/__init__.py
@@ -19,6 +19,7 @@ LOG_SCHEMA_FIELDS = [
     "db_phase",
     "method",
     "message",
+    "derived_message",
 ]
 
 SHERLOCK_PROMPT = """Continuous skepticism (Sherlock Protocol)\n* Could this change affect unexpected files/systems?\n* Any hidden dependencies or cascades?\n* What edge cases and failure modes are unhandled?\n* If stuck, work backward from the desired outcome."""
@@ -39,8 +40,12 @@ class StructuredFormatter(logging.Formatter):
         payload.setdefault("db_phase", record.__dict__.get("db_phase", "none"))
         payload.setdefault("method", record.__dict__.get("method", "NONE"))
         payload.setdefault("error", record.__dict__.get("error"))
+        payload.setdefault("derived_message", record.__dict__.get("derived_message"))
 
         json_line = json.dumps(payload, ensure_ascii=False)
+        derived = record.__dict__.get("derived_message")
+        if derived:
+            return f"{json_line}\n{derived}\n{SHERLOCK_PROMPT}"
         return f"{json_line}\n{SHERLOCK_PROMPT}"
 
 


### PR DESCRIPTION
## Summary
- avoid overwriting the LogRecord `message` field in the CLI VAD fallback path and surface derived Sherlock prompts via the structured formatter
- add regression coverage for the CLI run command when the VAD model is missing and for the structured formatter output
- record the completed logging work in the task tracker

## Testing
- poetry run ruff check
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed630a4880832b88713faeffbaa399