### PR TITLE
Handle missing Faster-Whisper assets gracefully

### DIFF
--- a/task.md
+++ b/task.md
@@ -19,3 +19,4 @@
 - [x] Prevent CLI VAD fallback logging from overwriting reserved LogRecord fields.
 - [x] Emit derived Sherlock prompt lines from the structured formatter output.
 - [x] Add regression coverage for CLI run VAD fallback and structured logging output.
+- [x] Surface actionable error when Faster-Whisper assets are missing.

--- a/tests/test_asr_engines.py
+++ b/tests/test_asr_engines.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -16,7 +17,7 @@ def _audio_chunk() -> bytes:
     return np.ones(1600, dtype=np.float32).tobytes()
 
 
-def test_faster_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_faster_whisper_engine_transcribes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     segments = [
         types.SimpleNamespace(text=" hello", end=0.5, avg_log_prob=np.log(0.9)),
         types.SimpleNamespace(text="world", end=1.0, avg_log_prob=np.log(0.8)),
@@ -33,8 +34,11 @@ def test_faster_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setitem(sys.modules, "faster_whisper", types.SimpleNamespace(WhisperModel=DummyModel))
 
+    model_file = tmp_path / "model.bin"
+    model_file.write_bytes(b"model")
+
     config = AsrConfig.model_validate(
-        {"asr_backend": "faster-whisper", "asr_model": "model.bin", "asr_device": "cpu"}
+        {"asr_backend": "faster-whisper", "asr_model": str(model_file), "asr_device": "cpu"}
     )
     engine = create_asr_engine(config)
     assert isinstance(engine, FasterWhisperEngine)
@@ -51,6 +55,25 @@ def test_faster_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> N
     assert partials == ["hello", "world"]
     assert finals == ["world"]
     assert confidences == [0.75]
+
+
+def test_faster_whisper_engine_missing_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "faster_whisper", types.SimpleNamespace(WhisperModel=object))
+
+    missing = tmp_path / "missing-model"
+    config = AsrConfig.model_validate(
+        {
+            "asr_backend": "faster-whisper",
+            "asr_model": str(missing),
+            "asr_device": "cpu",
+        }
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        create_asr_engine(config)
+
+    assert str(missing.resolve()) in str(excinfo.value)
+    assert "voice-agent models pull" in str(excinfo.value)
 
 
 def test_mlx_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -39,10 +39,29 @@ class FasterWhisperEngine(AsrEngine):
             module = importlib.import_module("faster_whisper")
         WhisperModel = getattr(module, "WhisperModel")
 
+        resolved_path = Path(model_path).expanduser()
+        if not resolved_path.is_absolute():
+            resolved_path = Path.cwd() / resolved_path
+        resolved_path = resolved_path.resolve()
+
+        if not resolved_path.exists():
+            error_message = f"Model missing at {resolved_path}"
+            _LOG.error(
+                "[Continuous skepticism (Sherlock Protocol)] Failed to load Faster-Whisper model",
+                extra={
+                    "classname": self.__class__.__name__,
+                    "function": "__init__",
+                    "system_section": "asr",
+                    "error": error_message,
+                    "structured_message": "Run voice-agent models pull asr/faster-whisper-base",
+                },
+            )
+            raise RuntimeError(f"{error_message}. Run voice-agent models pull asr/faster-whisper-base")
+
         self.language = language
         self.beam_size = beam_size
         compute = compute_type or ("int8" if device == "cpu" else "float16")
-        self._model = WhisperModel(str(model_path), device=device, compute_type=compute)
+        self._model = WhisperModel(str(resolved_path), device=device, compute_type=compute)
 
     def transcribe(self, audio_stream: Iterable[bytes]) -> None:
         audio = stream_to_numpy(audio_stream)


### PR DESCRIPTION
## Summary
- validate Faster-Whisper model paths before loading and surface actionable errors when assets are missing
- cover the missing-asset scenario and updated path handling in the ASR engine tests
- record the completed maintenance task in the task tracker

## Testing
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ed664e0790832bbd25746136341fa7