### PR TITLE
Enable multi-turn loopback sessions

### DIFF
--- a/task.md
+++ b/task.md
@@ -20,3 +20,5 @@
 - [x] Emit derived Sherlock prompt lines from the structured formatter output.
 - [x] Add regression coverage for CLI run VAD fallback and structured logging output.
 - [x] Surface actionable error when Faster-Whisper assets are missing.
+- [x] Ensure Sherlock-derived logs include derived metadata for ASR fallbacks.
+- [x] Extend CLI loopback run command to support multi-turn sessions.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from voice_agent.cli.app import _download_file, app
 from voice_agent.config import ConfigManager
+from voice_agent.asr import AsrEngine, AsrEvent
 
 runner = CliRunner()
 
@@ -130,7 +131,11 @@ def test_models_pull_prefers_option_destination_when_both_provided(tmp_path: Pat
         )
 
     assert result.exit_code == 0
-    assert "Warning: Positional destination ignored because --dest was provided" in result.stderr
+    if result.stderr_bytes is None:
+        warning_output = result.stdout
+    else:
+        warning_output = result.stderr
+    assert "Warning: Positional destination ignored because --dest was provided" in warning_output
     assert {call.args[1] for call in mock_download.call_args_list} == {
         option / "kitten_tts_nano_v0_2.onnx",
         option / "voices.npz",
@@ -159,10 +164,47 @@ def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             app,
-            ["run"],
+            ["run", "--turns", "1"],
             env={"VOICE_AGENT_CONFIG": str(config_path)},
         )
 
     assert result.exit_code == 0
-    assert "Loopback complete" in result.stdout
+    assert "Loopback turn 1 complete" in result.stdout
+    assert "Loopback session complete" in result.stdout
     assert mock_visualizer.return_value.run_demo.called
+
+
+def test_run_supports_multiple_turns(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    ConfigManager(config_path=config_path)
+
+    dummy_audio = mock.Mock()
+    dummy_audio.samplerate = 16000
+    dummy_audio.record_loopback.side_effect = [
+        np.zeros((160, 1), dtype=np.float32),
+        np.zeros((160, 1), dtype=np.float32),
+    ]
+
+    class DummyAsr(AsrEngine):
+        def transcribe(self, audio_stream):  # type: ignore[override]
+            self.emit_final(AsrEvent(text="hi", timestamp=0.0, confidence=0.5))
+
+    with (
+        mock.patch("voice_agent.cli.app.AudioIO", return_value=dummy_audio),
+        mock.patch("voice_agent.cli.app.SileroVadStream.from_numpy", return_value=["vad"]),
+        mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
+        mock.patch(
+            "voice_agent.cli.app.create_asr_engine",
+            side_effect=[DummyAsr(), DummyAsr()],
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["run", "--turns", "2"],
+            env={"VOICE_AGENT_CONFIG": str(config_path)},
+        )
+
+    assert result.exit_code == 0
+    assert dummy_audio.record_loopback.call_count == 2
+    assert result.stdout.count("Loopback turn") == 2
+    assert mock_visualizer.return_value.render_vad.call_count == 2

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -54,6 +54,7 @@ class FasterWhisperEngine(AsrEngine):
                     "system_section": "asr",
                     "error": error_message,
                     "structured_message": "Run voice-agent models pull asr/faster-whisper-base",
+                    "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate missing Faster-Whisper assets",
                 },
             )
             raise RuntimeError(f"{error_message}. Run voice-agent models pull asr/faster-whisper-base")

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -60,6 +60,12 @@ def run(
     seconds: float = typer.Option(3.0, help="Number of seconds to record"),
     input_device: Optional[str] = typer.Option(None, help="Input device name or index"),
     output_device: Optional[str] = typer.Option(None, help="Output device name or index"),
+    turns: int = typer.Option(
+        0,
+        "--turns",
+        min=0,
+        help="Number of turns to run (0 for continuous until interrupted)",
+    ),
 ) -> None:
     """Run an audio loopback demo with the dot visualizer."""
 
@@ -67,89 +73,107 @@ def run(
     config = manager.load()
     audio = AudioIO(samplerate=16000)
     visualizer = DotsVisualizer()
-    data = audio.record_loopback(seconds=seconds, input_device=input_device, output_device=output_device)
     profile = config.active()
     vad_model_path = profile.vad.model_path.expanduser()
-    try:
-        vad_stream = SileroVadStream.from_numpy(
-            audio=data,
-            model_path=vad_model_path,
-            sample_rate=audio.samplerate,
-            trigger_level=profile.vad.trigger_level,
-            release_level=profile.vad.release_level,
-            sensitivity=profile.vad.sensitivity,
-        )
-    except FileNotFoundError as exc:
-        _LOG.warning(
-            "VAD model missing",
-            extra={
-                "classname": "CLI",
-                "function": "run",
-                "system_section": "vad",
-                "error": str(exc),
-                "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
-            },
-        )
-        visualizer.run_demo(data)
-    except SileroVadError as exc:
-        _LOG.error(
-            "VAD initialisation failed",
-            extra={
-                "classname": "CLI",
-                "function": "run",
-                "system_section": "vad",
-                "error": str(exc),
-                "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
-            },
-        )
-        visualizer.run_demo(data)
-    else:
-        visualizer.render_vad(vad_stream, fallback_audio=data)
-
-    asr_partials: list[str] = []
-    asr_finals: list[AsrEvent] = []
-    asr_confidence: list[float] = []
+    max_turns = None if turns == 0 else turns
+    typer.echo("Starting loopback session. Press Ctrl+C to exit.")
+    completed_turns = 0
 
     try:
-        asr_engine = create_asr_engine(profile.asr)
-    except RuntimeError as exc:
-        _LOG.warning(
-            "[Continuous skepticism (Sherlock Protocol)] Falling back to visualiser-only mode",
-            extra={
-                "classname": "CLI",
-                "function": "run",
-                "system_section": "asr",
-                "error": str(exc),
-                "structured_message": "ASR backend unavailable",
-            },
-        )
-    else:
-        asr_engine.on_partial(lambda event: asr_partials.append(event.text))
-        asr_engine.on_final(asr_finals.append)
-        asr_engine.on_confidence(lambda value: asr_confidence.append(value))
-        audio_bytes = [np.ascontiguousarray(data, dtype=np.float32).reshape(-1).tobytes()]
-        try:
-            asr_engine.transcribe(audio_bytes)
-        except Exception as exc:  # pragma: no cover - backend specific failures
-            _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] Check ASR backend configuration",
-                extra={
-                    "classname": "CLI",
-                    "function": "run",
-                    "system_section": "asr",
-                    "error": str(exc),
-                    "structured_message": "ASR transcription failed",
-                },
+        while max_turns is None or completed_turns < max_turns:
+            completed_turns += 1
+            typer.echo(f"\n--- Turn {completed_turns} ---")
+            data = audio.record_loopback(
+                seconds=seconds,
+                input_device=input_device,
+                output_device=output_device,
             )
-        else:
-            if asr_partials:
-                visualizer.render_partial(asr_partials)
-            if asr_finals:
-                typer.echo(f"Final transcript: {asr_finals[-1].text}")
-            if asr_confidence:
-                typer.echo(f"Language confidence: {asr_confidence[-1]:.2f}")
 
-    typer.echo("Loopback complete")
+            try:
+                vad_stream = SileroVadStream.from_numpy(
+                    audio=data,
+                    model_path=vad_model_path,
+                    sample_rate=audio.samplerate,
+                    trigger_level=profile.vad.trigger_level,
+                    release_level=profile.vad.release_level,
+                    sensitivity=profile.vad.sensitivity,
+                )
+            except FileNotFoundError as exc:
+                _LOG.warning(
+                    "VAD model missing",
+                    extra={
+                        "classname": "CLI",
+                        "function": "run",
+                        "system_section": "vad",
+                        "error": str(exc),
+                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                    },
+                )
+                visualizer.run_demo(data)
+            except SileroVadError as exc:
+                _LOG.error(
+                    "VAD initialisation failed",
+                    extra={
+                        "classname": "CLI",
+                        "function": "run",
+                        "system_section": "vad",
+                        "error": str(exc),
+                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                    },
+                )
+                visualizer.run_demo(data)
+            else:
+                visualizer.render_vad(vad_stream, fallback_audio=data)
+
+            try:
+                asr_engine = create_asr_engine(profile.asr)
+            except RuntimeError as exc:
+                _LOG.warning(
+                    "[Continuous skepticism (Sherlock Protocol)] Falling back to visualiser-only mode",
+                    extra={
+                        "classname": "CLI",
+                        "function": "run",
+                        "system_section": "asr",
+                        "error": str(exc),
+                        "structured_message": "ASR backend unavailable",
+                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate ASR backend availability",
+                    },
+                )
+            else:
+                asr_partials: list[str] = []
+                asr_finals: list[AsrEvent] = []
+                asr_confidence: list[float] = []
+
+                asr_engine.on_partial(lambda event: asr_partials.append(event.text))
+                asr_engine.on_final(asr_finals.append)
+                asr_engine.on_confidence(lambda value: asr_confidence.append(value))
+                audio_bytes = [np.ascontiguousarray(data, dtype=np.float32).reshape(-1).tobytes()]
+                try:
+                    asr_engine.transcribe(audio_bytes)
+                except Exception as exc:  # pragma: no cover - backend specific failures
+                    _LOG.error(
+                        "[Continuous skepticism (Sherlock Protocol)] Check ASR backend configuration",
+                        extra={
+                            "classname": "CLI",
+                            "function": "run",
+                            "system_section": "asr",
+                            "error": str(exc),
+                            "structured_message": "ASR transcription failed",
+                        },
+                    )
+                else:
+                    if asr_partials:
+                        visualizer.render_partial(asr_partials)
+                    if asr_finals:
+                        typer.echo(f"Final transcript: {asr_finals[-1].text}")
+                    if asr_confidence:
+                        typer.echo(f"Language confidence: {asr_confidence[-1]:.2f}")
+
+            typer.echo(f"Loopback turn {completed_turns} complete")
+    except KeyboardInterrupt:
+        typer.echo("\nLoopback interrupted by user")
+
+    typer.echo("Loopback session complete")
 
 
 @bench_app.command("llm")


### PR DESCRIPTION
## Summary
- add a --turns option to the loopback CLI and repeat VAD/ASR handling for each requested turn
- expand CLI tests to cover multiple turn runs and resilient warning capture
- record the completed multi-turn work item in the task tracker

## Testing
- poetry run ruff check
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed6ca58690832bbbdccc5c61b873c5