### PR TITLE
Add Tauri desktop dev helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ End-to-end build and validation scripts are available for both Linux and macOS. 
 
 Both scripts accept `SKIP_SYSTEM_DEPS=1` to bypass package manager checks if PortAudio headers are already installed. Set the `PYTHON` environment variable to point at a specific Python 3.11+ interpreter when needed. Override `POETRY_EXTRAS` (defaults to `"tts asr audio"`) to trim optional dependencies when GPU-heavy wheels are unnecessary.
 
+### Desktop Dev Shell
+
+The `scripts/start_desktop.sh` helper launches the Tauri desktop workspace and its companion web frontend. It validates the expected directory structure, installs the web dependencies, and proxies arguments to `cargo tauri dev`:
+
+```bash
+./scripts/start_desktop.sh
+```
+
+By default the script expects:
+
+- A Tauri project at `apps/desktop` containing `src-tauri/Cargo.toml`.
+- A web frontend at `apps/web` with a `package.json` file.
+
+Override the locations with `DESKTOP_APP_ROOT` and `DESKTOP_WEB_DIR` if your checkout uses a different layout (for example, when the desktop or web projects live outside the repository root). Install `cargo-tauri` and Node.js + npm before running the script. Set `SKIP_NPM_INSTALL=1` to reuse existing frontend dependencies when you know the `node_modules` tree is already up to date.
+
 ### CLI Usage
 
 ```

--- a/scripts/start_desktop.sh
+++ b/scripts/start_desktop.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'err=$?; log_event "Desktop dev shell failed with exit code $err" "failure" "error"; exit $err' ERR
+
+json_escape() {
+  local str="$1"
+  str=${str//\\/\\\\}
+  str=${str//\"/\\\"}
+  str=${str//$'\n'/\\n}
+  printf '%s' "$str"
+}
+
+log_event() {
+  local message="$1"
+  local section="${2:-setup}"
+  local level="${3:-info}"
+  local error_flag=false
+  if [[ "$level" == "error" ]]; then
+    error_flag=true
+  fi
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local func_name="${FUNCNAME[1]:-main}"
+  local line_number="${BASH_LINENO[0]:-0}"
+  local escaped_message
+  escaped_message=$(json_escape "$message")
+  printf '{"filename":"scripts/start_desktop.sh","timestamp":"%s","classname":"StartDesktop","function":"%s","system_section":"%s","line_num":%s,"error":%s,"db_phase":"none","method":"NONE","message":"%s"}\n' \
+    "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
+}
+
+print_sherlock_prompt() {
+  cat <<'PROMPT'
+[Continuous skepticism (Sherlock Protocol)]
+* Could this change affect unexpected files/systems?
+* Any hidden dependencies or cascades?
+* What edge cases and failure modes are unhandled?
+* If stuck, work backward from the desired outcome.
+PROMPT
+}
+
+ensure_command() {
+  local cmd="$1"
+  local description="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_event "Required command '$cmd' for $description not found on PATH" "deps" "error"
+    cat >&2 <<ERR
+Missing dependency: $cmd
+Install $description and ensure it is available on your PATH before re-running this script.
+ERR
+    exit 1
+  fi
+}
+
+ensure_cargo_tauri() {
+  if ! cargo tauri --version >/dev/null 2>&1; then
+    log_event "cargo-tauri CLI not available" "deps" "error"
+    cat >&2 <<'ERR'
+The cargo-tauri CLI is required to launch the desktop shell.
+Install it via: cargo install tauri-cli
+ERR
+    exit 1
+  fi
+}
+
+main() {
+  print_sherlock_prompt
+
+  local project_root
+  project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  log_event "Project root detected at $project_root"
+
+  cd "$project_root"
+
+  local desktop_dir
+  desktop_dir="${DESKTOP_APP_ROOT:-$project_root/apps/desktop}"
+  local web_dir
+  web_dir="${DESKTOP_WEB_DIR:-$project_root/apps/web}"
+
+  log_event "Resolved desktop workspace to $desktop_dir" "paths"
+  log_event "Resolved web workspace to $web_dir" "paths"
+
+  if [[ ! -d "$desktop_dir" ]]; then
+    log_event "Desktop workspace directory not found" "paths" "error"
+    cat >&2 <<ERR
+Expected a Tauri desktop workspace at:
+  $desktop_dir
+Set DESKTOP_APP_ROOT to override the path or initialize the desktop workspace (e.g. git submodule, adjacent repository checkout).
+ERR
+    exit 1
+  fi
+
+  local tauri_manifest="$desktop_dir/src-tauri/Cargo.toml"
+  if [[ ! -f "$tauri_manifest" ]]; then
+    log_event "Tauri Cargo manifest missing at $tauri_manifest" "paths" "error"
+    cat >&2 <<ERR
+Missing src-tauri Cargo manifest at:
+  $tauri_manifest
+Ensure the desktop workspace contains a valid Tauri project structure.
+ERR
+    exit 1
+  fi
+
+  if [[ ! -d "$web_dir" ]]; then
+    log_event "Web workspace directory not found" "paths" "error"
+    cat >&2 <<ERR
+Expected a web frontend workspace at:
+  $web_dir
+Set DESKTOP_WEB_DIR to override the path or fetch the web assets (e.g. git submodule update or clone).
+ERR
+    exit 1
+  fi
+
+  local package_json="$web_dir/package.json"
+  if [[ ! -f "$package_json" ]]; then
+    log_event "package.json missing from web workspace" "paths" "error"
+    cat >&2 <<ERR
+package.json not found at:
+  $package_json
+Verify that the frontend dependencies have been checked out correctly.
+ERR
+    exit 1
+  fi
+
+  ensure_command npm "Node.js + npm"
+  ensure_command cargo "Rust toolchain"
+  ensure_cargo_tauri
+
+  if [[ "${SKIP_NPM_INSTALL:-0}" == "1" ]]; then
+    log_event "Skipping npm install because SKIP_NPM_INSTALL=1" "deps"
+  else
+    log_event "Installing frontend dependencies with npm" "deps"
+    npm install --prefix "$web_dir"
+  fi
+
+  log_event "Launching cargo-tauri dev shell" "desktop-run"
+  (cd "$desktop_dir" && cargo tauri dev "$@")
+
+  log_event "cargo-tauri dev shell exited cleanly" "complete"
+}
+
+main "$@"

--- a/task.md
+++ b/task.md
@@ -22,3 +22,4 @@
 - [x] Surface actionable error when Faster-Whisper assets are missing.
 - [x] Ensure Sherlock-derived logs include derived metadata for ASR fallbacks.
 - [x] Extend CLI loopback run command to support multi-turn sessions.
+- [x] Add desktop dev shell script with workspace validation for the Tauri frontend.


### PR DESCRIPTION
## Summary
- add a start_desktop.sh helper that validates the Tauri desktop and web workspaces, installs dependencies, and launches `cargo tauri dev`
- document the desktop dev shell usage, environment overrides, and npm install skip flag in the README
- record the completed desktop helper work in task.md

## Testing
- poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ed8bb51034832bbdef7a9b6a849009