### PR TITLE
Add Faster-Whisper auto-download and replace Sherlock review prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 ## Features
 
 - Python 3.11+ project managed with Poetry and structured `voice_agent` package layout.
-- Structured logging that emits JSON plus the Sherlock Protocol prompts for human review.
+- Structured logging that emits JSON plus a quality review checklist for human review.
 - Config profiles stored in TOML with validation, asset path checking, and a registry of supported models.
 - Audio loopback demo via PortAudio (`sounddevice`) with device selection flags.
 - Terminal dots visualizer showing VAD states, ASR partials, and simulated LLM token flow.

--- a/scripts/start_build_linux.sh
+++ b/scripts/start_build_linux.sh
@@ -29,13 +29,13 @@ log_event() {
     "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
 }
 
-print_sherlock_prompt() {
+print_review_prompt() {
   cat <<'PROMPT'
-[Continuous skepticism (Sherlock Protocol)]
-* Could this change affect unexpected files/systems?
-* Any hidden dependencies or cascades?
-* What edge cases and failure modes are unhandled?
-* If stuck, work backward from the desired outcome.
+Quality review checklist
+* Did we change only the systems we intended to touch?
+* Are all dependencies accounted for without hidden couplings?
+* Which edge cases or failure modes still need coverage?
+* If blocked, what outcome are we working backward from?
 PROMPT
 }
 
@@ -83,7 +83,7 @@ ensure_system_dependencies() {
 }
 
 main() {
-  print_sherlock_prompt
+  print_review_prompt
 
   local project_root
   project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/start_build_macos.sh
+++ b/scripts/start_build_macos.sh
@@ -29,13 +29,13 @@ log_event() {
     "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
 }
 
-print_sherlock_prompt() {
+print_review_prompt() {
   cat <<'PROMPT'
-[Continuous skepticism (Sherlock Protocol)]
-* Could this change affect unexpected files/systems?
-* Any hidden dependencies or cascades?
-* What edge cases and failure modes are unhandled?
-* If stuck, work backward from the desired outcome.
+Quality review checklist
+* Did we change only the systems we intended to touch?
+* Are all dependencies accounted for without hidden couplings?
+* Which edge cases or failure modes still need coverage?
+* If blocked, what outcome are we working backward from?
 PROMPT
 }
 
@@ -68,7 +68,7 @@ ERR
 }
 
 main() {
-  print_sherlock_prompt
+  print_review_prompt
 
   local project_root
   project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/task.md
+++ b/task.md
@@ -1,7 +1,7 @@
 # Project Tasks
 
 - [x] Scaffold Python project with Poetry, pyproject, and package structure.
-- [x] Implement structured logging with Sherlock Protocol prompts.
+- [x] Implement structured logging with quality review prompts.
 - [x] Add configuration management with profiles and asset validation.
 - [x] Provide audio loopback demo with CLI dots visualizer.
 - [x] Integrate Kitten TTS asset handling, voice listing, and playback commands.
@@ -17,8 +17,10 @@
 - [x] Improve `voice-agent models pull` destination handling for Typer 0.9 compatibility.
 - [x] Pin Click dependency to <8.2 to restore CLI help output.
 - [x] Prevent CLI VAD fallback logging from overwriting reserved LogRecord fields.
-- [x] Emit derived Sherlock prompt lines from the structured formatter output.
+- [x] Emit derived quality review prompt lines from the structured formatter output.
 - [x] Add regression coverage for CLI run VAD fallback and structured logging output.
 - [x] Surface actionable error when Faster-Whisper assets are missing.
-- [x] Ensure Sherlock-derived logs include derived metadata for ASR fallbacks.
+- [x] Ensure quality-review derived logs include derived metadata for ASR fallbacks.
+- [x] Add automatic Faster-Whisper model download when configured assets are missing.
+- [x] Replace Sherlock protocol references with the new quality review checklist across tooling.
 - [x] Extend CLI loopback run command to support multi-turn sessions.

--- a/tests/test_asr_engines.py
+++ b/tests/test_asr_engines.py
@@ -24,8 +24,14 @@ def test_faster_whisper_engine_transcribes(tmp_path: Path, monkeypatch: pytest.M
     ]
 
     class DummyModel:
-        def __init__(self, model_path: str, device: str, compute_type: str) -> None:  # noqa: ARG002
-            self.calls = [(model_path, device, compute_type)]
+        def __init__(
+            self,
+            model_path: str,
+            device: str,
+            compute_type: str,
+            download_options: dict | None = None,
+        ) -> None:  # noqa: ARG002
+            self.calls = [(model_path, device, compute_type, download_options)]
 
         def transcribe(self, audio: np.ndarray, language: str, beam_size: int):  # noqa: ARG002
             assert isinstance(audio, np.ndarray)
@@ -73,7 +79,47 @@ def test_faster_whisper_engine_missing_model(tmp_path: Path, monkeypatch: pytest
         create_asr_engine(config)
 
     assert str(missing.resolve()) in str(excinfo.value)
-    assert "voice-agent models pull" in str(excinfo.value)
+    assert "Provide a valid Faster-Whisper model path" in str(excinfo.value)
+
+
+def test_faster_whisper_engine_downloads_missing_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    created: dict[str, object] = {}
+
+    class DummyModel:
+        def __init__(
+            self,
+            model_path: str,
+            device: str,
+            compute_type: str,
+            download_options: dict | None = None,
+        ) -> None:
+            created.update(
+                {
+                    "model_path": model_path,
+                    "device": device,
+                    "compute_type": compute_type,
+                    "download_options": download_options,
+                }
+            )
+
+        def transcribe(self, audio: np.ndarray, language: str, beam_size: int):  # pragma: no cover - not executed
+            raise AssertionError("transcribe should not be invoked in constructor test")
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", types.SimpleNamespace(WhisperModel=DummyModel))
+
+    target_dir = tmp_path / "faster-whisper-base"
+    config = AsrConfig.model_validate(
+        {
+            "asr_backend": "faster-whisper",
+            "asr_model": str(target_dir),
+            "asr_device": "cpu",
+        }
+    )
+
+    create_asr_engine(config)
+
+    assert created["model_path"] == "base"
+    assert created["download_options"] == {"download_root": str(target_dir.resolve())}
 
 
 def test_mlx_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from voice_agent.logging import SHERLOCK_PROMPT, StructuredFormatter
+from voice_agent.logging import REVIEW_PROMPT, StructuredFormatter
 
 
 def test_structured_formatter_emits_derived_message() -> None:
@@ -17,7 +17,7 @@ def test_structured_formatter_emits_derived_message() -> None:
     record.classname = "TestCase"
     record.function = "test_structured_formatter_emits_derived_message"
     record.system_section = "logging"
-    record.derived_message = "[Continuous skepticism (Sherlock Protocol)] Test derived line"
+    record.derived_message = "Quality review: Test derived line"
 
     formatter = StructuredFormatter()
     formatted = formatter.format(record)
@@ -28,5 +28,5 @@ def test_structured_formatter_emits_derived_message() -> None:
     assert payload["message"] == "hello"
     assert payload["derived_message"] == record.derived_message
     assert lines[1] == record.derived_message
-    prompt_lines = SHERLOCK_PROMPT.splitlines()
+    prompt_lines = REVIEW_PROMPT.splitlines()
     assert lines[2:] == prompt_lines

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Dict, Iterable
 
 import numpy as np
 
@@ -15,6 +15,34 @@ from .base import AsrEngine, AsrEvent
 from .utils import stream_to_numpy
 
 _LOG = get_logger(__name__)
+
+
+MODEL_ALIAS_PREFIX = "faster-whisper-"
+
+MODEL_SIZE_ALIASES = {
+    "tiny": "tiny",
+    "tiny.en": "tiny.en",
+    "base": "base",
+    "base.en": "base.en",
+    "small": "small",
+    "small.en": "small.en",
+    "medium": "medium",
+    "medium.en": "medium.en",
+    "large": "large-v3",
+    "large-v2": "large-v2",
+    "large-v3": "large-v3",
+}
+
+
+def _resolve_pretrained_name(path: Path) -> str | None:
+    """Return the Faster-Whisper model identifier for a missing asset path."""
+
+    name = path.name.lower().replace("_", "-")
+    if name.startswith(MODEL_ALIAS_PREFIX):
+        candidate = name[len(MODEL_ALIAS_PREFIX) :]
+    else:
+        candidate = name
+    return MODEL_SIZE_ALIASES.get(candidate)
 
 
 class FasterWhisperEngine(AsrEngine):
@@ -44,31 +72,82 @@ class FasterWhisperEngine(AsrEngine):
             resolved_path = Path.cwd() / resolved_path
         resolved_path = resolved_path.resolve()
 
+        compute = compute_type or ("int8" if device == "cpu" else "float16")
+        download_options: Dict[str, str] | None = None
+        model_location: str | Path = resolved_path
+
         if not resolved_path.exists():
-            error_message = f"Model missing at {resolved_path}"
+            pretrained_name = _resolve_pretrained_name(resolved_path)
+            if pretrained_name:
+                resolved_path.mkdir(parents=True, exist_ok=True)
+                download_options = {"download_root": str(resolved_path)}
+                model_location = pretrained_name
+                _LOG.info(
+                    "Downloading Faster-Whisper model",
+                    extra={
+                        "classname": self.__class__.__name__,
+                        "function": "__init__",
+                        "system_section": "asr",
+                        "structured_message": str(
+                            {
+                                "pretrained": pretrained_name,
+                                "destination": str(resolved_path),
+                                "device": device,
+                                "compute_type": compute,
+                            }
+                        ),
+                        "derived_message": "Quality review: Missing ASR assets detected; downloading pretrained model",
+                    },
+                )
+            else:
+                error_message = f"Model missing at {resolved_path}"
+                _LOG.error(
+                    "Failed to load Faster-Whisper model",
+                    extra={
+                        "classname": self.__class__.__name__,
+                        "function": "__init__",
+                        "system_section": "asr",
+                        "error": error_message,
+                        "structured_message": "Provide a valid Faster-Whisper model path or alias",
+                        "derived_message": "Quality review: ASR backend cannot locate requested model assets",
+                    },
+                )
+                raise RuntimeError(
+                    f"{error_message}. Provide a valid Faster-Whisper model path or use a supported alias"
+                )
+
+        try:
+            if download_options is not None:
+                self._model = WhisperModel(
+                    model_location,
+                    device=device,
+                    compute_type=compute,
+                    download_options=download_options,
+                )
+            else:
+                self._model = WhisperModel(str(model_location), device=device, compute_type=compute)
+        except Exception as exc:  # pragma: no cover - backend import failures
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] Failed to load Faster-Whisper model",
+                "Failed to initialise Faster-Whisper model",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "__init__",
                     "system_section": "asr",
-                    "error": error_message,
-                    "structured_message": "Run voice-agent models pull asr/faster-whisper-base",
-                    "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate missing Faster-Whisper assets",
+                    "error": str(exc),
+                    "structured_message": str({"model": str(model_location), "device": device}),
+                    "derived_message": "Quality review: Faster-Whisper initialisation raised an exception",
                 },
             )
-            raise RuntimeError(f"{error_message}. Run voice-agent models pull asr/faster-whisper-base")
+            raise RuntimeError("Unable to initialise Faster-Whisper model") from exc
 
         self.language = language
         self.beam_size = beam_size
-        compute = compute_type or ("int8" if device == "cpu" else "float16")
-        self._model = WhisperModel(str(resolved_path), device=device, compute_type=compute)
 
     def transcribe(self, audio_stream: Iterable[bytes]) -> None:
         audio = stream_to_numpy(audio_stream)
         if audio.size == 0:
             _LOG.warning(
-                "[Continuous skepticism (Sherlock Protocol)] No frames to process",
+                "No audio frames to process",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "transcribe",
@@ -79,7 +158,7 @@ class FasterWhisperEngine(AsrEngine):
             return
 
         _LOG.info(
-            "[Continuous skepticism (Sherlock Protocol)] Running inference",
+            "Running Faster-Whisper inference",
             extra={
                 "classname": self.__class__.__name__,
                 "function": "transcribe",

--- a/voice_agent/asr/mlx_whisper.py
+++ b/voice_agent/asr/mlx_whisper.py
@@ -74,7 +74,7 @@ class MlxWhisperEngine(AsrEngine):
         audio = stream_to_numpy(audio_stream)
         if audio.size == 0:
             _LOG.warning(
-                "[Continuous skepticism (Sherlock Protocol)] No frames to process",
+                "No audio frames to process",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "transcribe",
@@ -86,7 +86,7 @@ class MlxWhisperEngine(AsrEngine):
 
         audio = np.ascontiguousarray(audio, dtype=np.float32)
         _LOG.info(
-            "[Continuous skepticism (Sherlock Protocol)] Running inference",
+            "Running MLX-Whisper inference",
             extra={
                 "classname": self.__class__.__name__,
                 "function": "transcribe",

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -106,7 +106,7 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                        "derived_message": "Quality review: Silero VAD assets unavailable; switching to RMS visualiser",
                     },
                 )
                 visualizer.run_demo(data)
@@ -118,7 +118,7 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                        "derived_message": "Quality review: VAD backend error; reverting to RMS visualiser",
                     },
                 )
                 visualizer.run_demo(data)
@@ -129,14 +129,14 @@ def run(
                 asr_engine = create_asr_engine(profile.asr)
             except RuntimeError as exc:
                 _LOG.warning(
-                    "[Continuous skepticism (Sherlock Protocol)] Falling back to visualiser-only mode",
+                    "ASR backend unavailable; continuing without transcription",
                     extra={
                         "classname": "CLI",
                         "function": "run",
                         "system_section": "asr",
                         "error": str(exc),
                         "structured_message": "ASR backend unavailable",
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate ASR backend availability",
+                        "derived_message": "Quality review: Investigate ASR configuration before enabling LLM+TTS turn",
                     },
                 )
             else:
@@ -152,7 +152,7 @@ def run(
                     asr_engine.transcribe(audio_bytes)
                 except Exception as exc:  # pragma: no cover - backend specific failures
                     _LOG.error(
-                        "[Continuous skepticism (Sherlock Protocol)] Check ASR backend configuration",
+                        "ASR transcription failed",
                         extra={
                             "classname": "CLI",
                             "function": "run",
@@ -198,7 +198,7 @@ def bench_llm(
         engine = create_llm_engine(runtime_config)
     except FileNotFoundError as exc:
         _LOG.error(
-            "[Continuous skepticism (Sherlock Protocol)] LLM model missing",
+            "LLM model missing",
             extra={
                 "classname": "CLI",
                 "function": "bench_llm",
@@ -215,7 +215,7 @@ def bench_llm(
             typer.echo(chunk, nl=False)
     except RuntimeError as exc:
         _LOG.error(
-            "[Continuous skepticism (Sherlock Protocol)] LLM streaming failed",
+            "LLM streaming failed",
             extra={
                 "classname": "CLI",
                 "function": "bench_llm",
@@ -358,7 +358,7 @@ def models_pull(
                 "error": None,
                 "db_phase": "none",
                 "method": "NONE",
-                "log_message": "[Continuous skepticism (Sherlock Protocol)] Only the first positional destination will be used",
+                "log_message": "Quality review: Only the first positional destination will be used",
             },
         )
         typer.echo(
@@ -379,7 +379,7 @@ def models_pull(
                 "error": None,
                 "db_phase": "none",
                 "method": "NONE",
-                "log_message": "[Continuous skepticism (Sherlock Protocol)] Positional destination ignored in favour of --dest",
+                "log_message": "Quality review: Positional destination ignored in favour of --dest",
             },
         )
         typer.echo(
@@ -439,7 +439,7 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "asr",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise ASR backend",
+                "structured_message": "Quality review: Unable to initialise ASR backend",
             },
         )
         metrics["asr"] = {"error": str(exc)}
@@ -465,7 +465,7 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "llm",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise LLM backend",
+                "structured_message": "Quality review: Unable to initialise LLM backend",
             },
         )
         metrics["llm"] = {"error": str(exc)}
@@ -483,7 +483,7 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "tts",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise TTS backend",
+                "structured_message": "Quality review: Unable to initialise TTS backend",
             },
         )
         metrics["tts"] = {"error": str(exc)}

--- a/voice_agent/llm/llama_cpp.py
+++ b/voice_agent/llm/llama_cpp.py
@@ -32,7 +32,7 @@ class LlamaCppEngine(LlmEngine):
         model_path = self._config.model_path.expanduser()
         if not model_path.exists():
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] Failed to load llama.cpp model",
+                "Failed to load llama.cpp model",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "_initialise_model",
@@ -98,7 +98,7 @@ class LlamaCppEngine(LlmEngine):
             iterator: Iterator[Dict[str, object]] = self._model.create_completion(**request_kwargs)
         except Exception as exc:  # pragma: no cover - backend raises varying errors
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] llama.cpp completion failed",
+                "llama.cpp completion failed",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "stream",

--- a/voice_agent/logging/__init__.py
+++ b/voice_agent/logging/__init__.py
@@ -22,7 +22,7 @@ LOG_SCHEMA_FIELDS = [
     "derived_message",
 ]
 
-SHERLOCK_PROMPT = """Continuous skepticism (Sherlock Protocol)\n* Could this change affect unexpected files/systems?\n* Any hidden dependencies or cascades?\n* What edge cases and failure modes are unhandled?\n* If stuck, work backward from the desired outcome."""
+REVIEW_PROMPT = """Quality review checklist\n* Did we change only the systems we intended to touch?\n* Are all dependencies accounted for without hidden couplings?\n* Which edge cases or failure modes still need coverage?\n* If blocked, what outcome are we working backward from?"""
 
 
 class StructuredFormatter(logging.Formatter):
@@ -45,8 +45,8 @@ class StructuredFormatter(logging.Formatter):
         json_line = json.dumps(payload, ensure_ascii=False)
         derived = record.__dict__.get("derived_message")
         if derived:
-            return f"{json_line}\n{derived}\n{SHERLOCK_PROMPT}"
-        return f"{json_line}\n{SHERLOCK_PROMPT}"
+            return f"{json_line}\n{derived}\n{REVIEW_PROMPT}"
+        return f"{json_line}\n{REVIEW_PROMPT}"
 
 
 def configure_logging(level: int = logging.INFO) -> None:

--- a/voice_agent/vad/silero.py
+++ b/voice_agent/vad/silero.py
@@ -156,7 +156,7 @@ class SileroVadStream(VadStream):
                     self._state = VadState.SPEECH
                     self._active_frames = 0
                     self._logger.info(
-                        "[Continuous skepticism (Sherlock Protocol)] Speech detected",
+                        "Speech detected",
                         extra={
                             "classname": self.__class__.__name__,
                             "function": "__iter__",
@@ -168,7 +168,7 @@ class SileroVadStream(VadStream):
                     self._state = VadState.SILENCE
                     self._inactive_frames = 0
                     self._logger.info(
-                        "[Continuous skepticism (Sherlock Protocol)] Speech ended",
+                        "Speech ended",
                         extra={
                             "classname": self.__class__.__name__,
                             "function": "__iter__",


### PR DESCRIPTION
## Summary
- add automatic Faster-Whisper model download support when assets are missing and update ASR logging
- replace Sherlock protocol text with the new quality review checklist across runtime and tooling
- refresh tests and docs to reflect the revised logging prompts

## Testing
- `poetry run pytest`
- `poetry run ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ed8d2f1710832ba39f0b19b21e8c7b