### PR TITLE
Enable Smart-Turn CLI flow and remove Sherlock prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 ## Features
 
 - Python 3.11+ project managed with Poetry and structured `voice_agent` package layout.
-- Structured logging that emits JSON plus the Sherlock Protocol prompts for human review.
+- Structured logging that emits JSON with optional derived guidance lines for human review.
 - Config profiles stored in TOML with validation, asset path checking, and a registry of supported models.
 - Audio loopback demo via PortAudio (`sounddevice`) with device selection flags.
 - Terminal dots visualizer showing VAD states, ASR partials, and simulated LLM token flow.
@@ -71,7 +71,7 @@ poetry run voice-agent --help
 
 Common commands:
 
-- `poetry run voice-agent run --seconds 5` — record and playback a loopback sample with live dots visualizer.
+- `poetry run voice-agent run --seconds 5` — capture a loopback sample, drive Smart-Turn orchestration, and render live dots when models are available.
 - `poetry run voice-agent audio-devices` — list available input/output devices.
 - `poetry run voice-agent profile list` — enumerate configuration profiles.
 - `poetry run voice-agent profile use fast-mlx` — switch to the MLX Whisper profile.

--- a/scripts/start_build_linux.sh
+++ b/scripts/start_build_linux.sh
@@ -29,9 +29,9 @@ log_event() {
     "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
 }
 
-print_sherlock_prompt() {
+print_quality_prompt() {
   cat <<'PROMPT'
-[Continuous skepticism (Sherlock Protocol)]
+[Quality checklist]
 * Could this change affect unexpected files/systems?
 * Any hidden dependencies or cascades?
 * What edge cases and failure modes are unhandled?
@@ -83,7 +83,7 @@ ensure_system_dependencies() {
 }
 
 main() {
-  print_sherlock_prompt
+  print_quality_prompt
 
   local project_root
   project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/start_build_macos.sh
+++ b/scripts/start_build_macos.sh
@@ -29,9 +29,9 @@ log_event() {
     "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
 }
 
-print_sherlock_prompt() {
+print_quality_prompt() {
   cat <<'PROMPT'
-[Continuous skepticism (Sherlock Protocol)]
+[Quality checklist]
 * Could this change affect unexpected files/systems?
 * Any hidden dependencies or cascades?
 * What edge cases and failure modes are unhandled?
@@ -68,7 +68,7 @@ ERR
 }
 
 main() {
-  print_sherlock_prompt
+  print_quality_prompt
 
   local project_root
   project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/start_desktop.sh
+++ b/scripts/start_desktop.sh
@@ -29,9 +29,9 @@ log_event() {
     "$timestamp" "$func_name" "$section" "$line_number" "$error_flag" "$escaped_message"
 }
 
-print_sherlock_prompt() {
+print_quality_prompt() {
   cat <<'PROMPT'
-[Continuous skepticism (Sherlock Protocol)]
+[Quality checklist]
 * Could this change affect unexpected files/systems?
 * Any hidden dependencies or cascades?
 * What edge cases and failure modes are unhandled?
@@ -64,7 +64,7 @@ ERR
 }
 
 main() {
-  print_sherlock_prompt
+  print_quality_prompt
 
   local project_root
   project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/task.md
+++ b/task.md
@@ -23,3 +23,5 @@
 - [x] Ensure Sherlock-derived logs include derived metadata for ASR fallbacks.
 - [x] Extend CLI loopback run command to support multi-turn sessions.
 - [x] Add desktop dev shell script with workspace validation for the Tauri frontend.
+- [x] Replace Sherlock Protocol prompts with a neutral quality checklist across logging and scripts.
+- [x] Integrate Smart-Turn orchestration into the CLI run command with ASR/LLM/TTS playback.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ from typer.testing import CliRunner
 
 from voice_agent.cli.app import _download_file, app
 from voice_agent.config import ConfigManager
-from voice_agent.asr import AsrEngine, AsrEvent
 
 runner = CliRunner()
 
@@ -169,6 +168,7 @@ def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0
+    assert "ASR/LLM/TTS pipeline unavailable" in result.stdout
     assert "Loopback turn 1 complete" in result.stdout
     assert "Loopback session complete" in result.stdout
     assert mock_visualizer.return_value.run_demo.called
@@ -185,19 +185,28 @@ def test_run_supports_multiple_turns(tmp_path: Path) -> None:
         np.zeros((160, 1), dtype=np.float32),
     ]
 
-    class DummyAsr(AsrEngine):
-        def transcribe(self, audio_stream):  # type: ignore[override]
-            self.emit_final(AsrEvent(text="hi", timestamp=0.0, confidence=0.5))
-
     with (
         mock.patch("voice_agent.cli.app.AudioIO", return_value=dummy_audio),
         mock.patch("voice_agent.cli.app.SileroVadStream.from_numpy", return_value=["vad"]),
         mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
-        mock.patch(
-            "voice_agent.cli.app.create_asr_engine",
-            side_effect=[DummyAsr(), DummyAsr()],
-        ),
+        mock.patch("voice_agent.cli.app.create_asr_engine", return_value=mock.Mock()),
+        mock.patch("voice_agent.cli.app.create_llm_engine", return_value=mock.Mock()),
+        mock.patch("voice_agent.cli.app.KittenTTS", return_value=mock.Mock()),
+        mock.patch("voice_agent.cli.app.SmartTurnOrchestrator") as mock_orchestrator_cls,
     ):
+        result_sequence = []
+        for idx in range(2):
+            payload = mock.Mock()
+            payload.transcript = f"hi-{idx}"
+            payload.response = f"response-{idx}"
+            payload.partials = (f"partial-{idx}",)
+            payload.confidences = (0.9,)
+            payload.metrics = {"utterance_ms": 123.0 + idx}
+            result_sequence.append(payload)
+        orchestrator_instance = mock.Mock()
+        orchestrator_instance.run.side_effect = result_sequence
+        mock_orchestrator_cls.return_value = orchestrator_instance
+
         result = runner.invoke(
             app,
             ["run", "--turns", "2"],
@@ -207,4 +216,7 @@ def test_run_supports_multiple_turns(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert dummy_audio.record_loopback.call_count == 2
     assert result.stdout.count("Loopback turn") == 2
+    assert orchestrator_instance.run.call_count == 2
+    assert "Transcript: hi-0" in result.stdout
+    assert "Response: response-1" in result.stdout
     assert mock_visualizer.return_value.render_vad.call_count == 2

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from voice_agent.logging import SHERLOCK_PROMPT, StructuredFormatter
+from voice_agent.logging import StructuredFormatter
 
 
 def test_structured_formatter_emits_derived_message() -> None:
@@ -17,16 +17,14 @@ def test_structured_formatter_emits_derived_message() -> None:
     record.classname = "TestCase"
     record.function = "test_structured_formatter_emits_derived_message"
     record.system_section = "logging"
-    record.derived_message = "[Continuous skepticism (Sherlock Protocol)] Test derived line"
+    record.derived_message = "Derived guidance: Test derived line"
 
     formatter = StructuredFormatter()
     formatted = formatter.format(record)
     lines = formatted.splitlines()
 
-    assert len(lines) == 7
+    assert len(lines) == 2
     payload = json.loads(lines[0])
     assert payload["message"] == "hello"
     assert payload["derived_message"] == record.derived_message
     assert lines[1] == record.derived_message
-    prompt_lines = SHERLOCK_PROMPT.splitlines()
-    assert lines[2:] == prompt_lines

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -47,14 +47,14 @@ class FasterWhisperEngine(AsrEngine):
         if not resolved_path.exists():
             error_message = f"Model missing at {resolved_path}"
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] Failed to load Faster-Whisper model",
+                "Failed to load Faster-Whisper model",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "__init__",
                     "system_section": "asr",
                     "error": error_message,
                     "structured_message": "Run voice-agent models pull asr/faster-whisper-base",
-                    "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate missing Faster-Whisper assets",
+                    "derived_message": "ASR assets missing; run `voice-agent models pull asr/faster-whisper-base`",
                 },
             )
             raise RuntimeError(f"{error_message}. Run voice-agent models pull asr/faster-whisper-base")
@@ -68,18 +68,19 @@ class FasterWhisperEngine(AsrEngine):
         audio = stream_to_numpy(audio_stream)
         if audio.size == 0:
             _LOG.warning(
-                "[Continuous skepticism (Sherlock Protocol)] No frames to process",
+                "No audio frames available for Faster-Whisper",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "transcribe",
                     "system_section": "asr",
                     "structured_message": "Empty audio stream received",
+                    "derived_message": "Check microphone input and retry",
                 },
             )
             return
 
         _LOG.info(
-            "[Continuous skepticism (Sherlock Protocol)] Running inference",
+            "Starting Faster-Whisper transcription",
             extra={
                 "classname": self.__class__.__name__,
                 "function": "transcribe",

--- a/voice_agent/asr/mlx_whisper.py
+++ b/voice_agent/asr/mlx_whisper.py
@@ -74,19 +74,20 @@ class MlxWhisperEngine(AsrEngine):
         audio = stream_to_numpy(audio_stream)
         if audio.size == 0:
             _LOG.warning(
-                "[Continuous skepticism (Sherlock Protocol)] No frames to process",
+                "No audio frames available for MLX Whisper",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "transcribe",
                     "system_section": "asr",
                     "structured_message": "Empty audio stream received",
+                    "derived_message": "Check microphone input and retry",
                 },
             )
             return
 
         audio = np.ascontiguousarray(audio, dtype=np.float32)
         _LOG.info(
-            "[Continuous skepticism (Sherlock Protocol)] Running inference",
+            "Starting MLX Whisper transcription",
             extra={
                 "classname": self.__class__.__name__,
                 "function": "transcribe",

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -19,12 +19,13 @@ from voice_agent.benchmarks import (
     measure_llm_latency,
     measure_tts_latency,
 )
-from voice_agent.asr import AsrEvent, create_asr_engine
+from voice_agent.asr import create_asr_engine
 from voice_agent.audio import AudioIO
 from voice_agent.cli.visualizer import DotsVisualizer
 from voice_agent.config import ConfigManager
 from voice_agent.llm import LlmConfig as RuntimeLlmConfig, create_llm_engine
 from voice_agent.logging import configure_logging, get_logger
+from voice_agent.runtime import SmartTurnError, SmartTurnOrchestrator
 from voice_agent.telemetry import TelemetryClient
 from voice_agent.tts import KittenTTS, load_voice_inventory
 from voice_agent.vad import SileroVadError, SileroVadStream
@@ -54,6 +55,16 @@ def _config_manager(config_path: Optional[Path]) -> ConfigManager:
     return ConfigManager(config_path=config_path) if config_path else ConfigManager()
 
 
+def _frame_audio(audio: np.ndarray, frame_samples: int) -> list[np.ndarray]:
+    data = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if data.size == 0:
+        return []
+    frames: list[np.ndarray] = []
+    for start in range(0, data.size, frame_samples):
+        frames.append(data[start : start + frame_samples])
+    return frames
+
+
 @app.command()
 def run(
     config_path: Optional[Path] = typer.Option(None, "--config-path", help="Override configuration path"),
@@ -67,17 +78,54 @@ def run(
         help="Number of turns to run (0 for continuous until interrupted)",
     ),
 ) -> None:
-    """Run an audio loopback demo with the dot visualizer."""
+    """Run an audio conversation loop with ASR, LLM, and TTS orchestration."""
 
     manager = _config_manager(config_path)
     config = manager.load()
     audio = AudioIO(samplerate=16000)
     visualizer = DotsVisualizer()
+    telemetry = TelemetryClient()
     profile = config.active()
     vad_model_path = profile.vad.model_path.expanduser()
     max_turns = None if turns == 0 else turns
     typer.echo("Starting loopback session. Press Ctrl+C to exit.")
     completed_turns = 0
+
+    orchestrator: SmartTurnOrchestrator | None = None
+    try:
+        asr_engine = create_asr_engine(profile.asr)
+        runtime_config = RuntimeLlmConfig(
+            model_path=profile.llm.model_path,
+            temperature=profile.llm.temperature,
+            top_p=profile.llm.top_p,
+            repeat_penalty=profile.llm.repeat_penalty,
+            context_window=profile.llm.context_window,
+        )
+        llm_engine = create_llm_engine(runtime_config)
+        tts_engine = KittenTTS(model_dir=profile.tts.model_dir, voice_id=profile.tts.voice_id)
+    except Exception as exc:
+        _LOG.error(
+            "Conversation pipeline initialisation failed",
+            extra={
+                "classname": "CLI",
+                "function": "run",
+                "system_section": "runtime",
+                "error": str(exc),
+                "structured_message": "ASR/LLM/TTS startup failed",
+                "derived_message": "Verify local model assets and configuration paths",
+            },
+        )
+        typer.echo("ASR/LLM/TTS pipeline unavailable; running visualizer-only mode.")
+    else:
+        orchestrator = SmartTurnOrchestrator(
+            asr_engine=asr_engine,
+            llm_engine=llm_engine,
+            tts_engine=tts_engine,
+            turn_config=profile.turn,
+            tts_config=profile.tts,
+            sample_rate=audio.samplerate,
+            telemetry=telemetry,
+        )
 
     try:
         while max_turns is None or completed_turns < max_turns:
@@ -106,10 +154,13 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                        "derived_message": "Install Silero VAD assets to enable turn detection",
                     },
                 )
                 visualizer.run_demo(data)
+                typer.echo("Turn processed without VAD; unable to drive conversation flow.")
+                typer.echo(f"Loopback turn {completed_turns} complete")
+                continue
             except SileroVadError as exc:
                 _LOG.error(
                     "VAD initialisation failed",
@@ -118,56 +169,50 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Falling back to RMS-based visualiser",
+                        "derived_message": "Review Silero configuration parameters",
                     },
                 )
                 visualizer.run_demo(data)
-            else:
-                visualizer.render_vad(vad_stream, fallback_audio=data)
+                typer.echo("Turn processed without VAD; unable to drive conversation flow.")
+                typer.echo(f"Loopback turn {completed_turns} complete")
+                continue
 
+            events = list(vad_stream)
+            visualizer.render_vad(events, fallback_audio=data)
+
+            if orchestrator is None:
+                typer.echo("Conversation pipeline unavailable; skipping ASR/LLM/TTS.")
+                typer.echo(f"Loopback turn {completed_turns} complete")
+                continue
+
+            audio_frames = _frame_audio(data, frame_samples=512)
             try:
-                asr_engine = create_asr_engine(profile.asr)
-            except RuntimeError as exc:
+                result = orchestrator.run(audio_frames, events)
+            except SmartTurnError as exc:
                 _LOG.warning(
-                    "[Continuous skepticism (Sherlock Protocol)] Falling back to visualiser-only mode",
+                    "Conversation turn failed",
                     extra={
                         "classname": "CLI",
                         "function": "run",
-                        "system_section": "asr",
+                        "system_section": "runtime",
                         "error": str(exc),
-                        "structured_message": "ASR backend unavailable",
-                        "derived_message": "[Continuous skepticism (Sherlock Protocol)] Investigate ASR backend availability",
+                        "structured_message": "Smart-Turn orchestration error",
+                        "derived_message": "Verify audio quality and timing thresholds",
                     },
                 )
+                typer.echo(f"Conversation turn failed: {exc}")
             else:
-                asr_partials: list[str] = []
-                asr_finals: list[AsrEvent] = []
-                asr_confidence: list[float] = []
-
-                asr_engine.on_partial(lambda event: asr_partials.append(event.text))
-                asr_engine.on_final(asr_finals.append)
-                asr_engine.on_confidence(lambda value: asr_confidence.append(value))
-                audio_bytes = [np.ascontiguousarray(data, dtype=np.float32).reshape(-1).tobytes()]
-                try:
-                    asr_engine.transcribe(audio_bytes)
-                except Exception as exc:  # pragma: no cover - backend specific failures
-                    _LOG.error(
-                        "[Continuous skepticism (Sherlock Protocol)] Check ASR backend configuration",
-                        extra={
-                            "classname": "CLI",
-                            "function": "run",
-                            "system_section": "asr",
-                            "error": str(exc),
-                            "structured_message": "ASR transcription failed",
-                        },
-                    )
-                else:
-                    if asr_partials:
-                        visualizer.render_partial(asr_partials)
-                    if asr_finals:
-                        typer.echo(f"Final transcript: {asr_finals[-1].text}")
-                    if asr_confidence:
-                        typer.echo(f"Language confidence: {asr_confidence[-1]:.2f}")
+                if result.partials:
+                    visualizer.render_partial(result.partials)
+                typer.echo(f"Transcript: {result.transcript}")
+                typer.echo(f"Response: {result.response}")
+                if result.confidences:
+                    typer.echo(f"Confidence: {result.confidences[-1]:.2f}")
+                for name, value in sorted(result.metrics.items()):
+                    if name.endswith("latency") or name.endswith("_ms"):
+                        typer.echo(f"{name}: {value:.2f} ms")
+                    else:
+                        typer.echo(f"{name}: {value}")
 
             typer.echo(f"Loopback turn {completed_turns} complete")
     except KeyboardInterrupt:
@@ -198,13 +243,14 @@ def bench_llm(
         engine = create_llm_engine(runtime_config)
     except FileNotFoundError as exc:
         _LOG.error(
-            "[Continuous skepticism (Sherlock Protocol)] LLM model missing",
+            "LLM model missing",
             extra={
                 "classname": "CLI",
                 "function": "bench_llm",
                 "system_section": "llm",
                 "error": str(exc),
                 "structured_message": "Run voice-agent models pull to download",
+                "derived_message": "Download the configured llama.cpp GGUF model before benchmarking",
             },
         )
         raise typer.BadParameter(str(exc)) from exc
@@ -215,13 +261,14 @@ def bench_llm(
             typer.echo(chunk, nl=False)
     except RuntimeError as exc:
         _LOG.error(
-            "[Continuous skepticism (Sherlock Protocol)] LLM streaming failed",
+            "LLM streaming failed",
             extra={
                 "classname": "CLI",
                 "function": "bench_llm",
                 "system_section": "llm",
                 "error": str(exc),
                 "structured_message": "Inspect llama.cpp configuration",
+                "derived_message": "Review llama.cpp logs for sampling issues",
             },
         )
         raise typer.Exit(code=1) from exc
@@ -358,7 +405,7 @@ def models_pull(
                 "error": None,
                 "db_phase": "none",
                 "method": "NONE",
-                "log_message": "[Continuous skepticism (Sherlock Protocol)] Only the first positional destination will be used",
+                "log_message": "Only the first positional destination will be used",
             },
         )
         typer.echo(
@@ -379,7 +426,7 @@ def models_pull(
                 "error": None,
                 "db_phase": "none",
                 "method": "NONE",
-                "log_message": "[Continuous skepticism (Sherlock Protocol)] Positional destination ignored in favour of --dest",
+                "log_message": "Positional destination ignored in favour of --dest",
             },
         )
         typer.echo(
@@ -439,7 +486,8 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "asr",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise ASR backend",
+                "structured_message": "Unable to initialise ASR backend",
+                "derived_message": "Confirm ASR model assets are available",
             },
         )
         metrics["asr"] = {"error": str(exc)}
@@ -465,7 +513,8 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "llm",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise LLM backend",
+                "structured_message": "Unable to initialise LLM backend",
+                "derived_message": "Ensure llama.cpp configuration is valid",
             },
         )
         metrics["llm"] = {"error": str(exc)}
@@ -483,7 +532,8 @@ def bench_latency(
                 "function": "bench_latency",
                 "system_section": "tts",
                 "error": str(exc),
-                "structured_message": "[Continuous skepticism (Sherlock Protocol)] Unable to initialise TTS backend",
+                "structured_message": "Unable to initialise TTS backend",
+                "derived_message": "Verify Kitten TTS assets are present",
             },
         )
         metrics["tts"] = {"error": str(exc)}

--- a/voice_agent/llm/llama_cpp.py
+++ b/voice_agent/llm/llama_cpp.py
@@ -32,13 +32,14 @@ class LlamaCppEngine(LlmEngine):
         model_path = self._config.model_path.expanduser()
         if not model_path.exists():
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] Failed to load llama.cpp model",
+                "Failed to load llama.cpp model",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "_initialise_model",
                     "system_section": "llm",
                     "error": f"Model missing at {model_path}",
                     "structured_message": "Verify GGUF asset path",
+                    "derived_message": "Ensure llama.cpp model assets are available locally",
                 },
             )
             raise FileNotFoundError(f"Model missing at {model_path}")
@@ -98,13 +99,14 @@ class LlamaCppEngine(LlmEngine):
             iterator: Iterator[Dict[str, object]] = self._model.create_completion(**request_kwargs)
         except Exception as exc:  # pragma: no cover - backend raises varying errors
             _LOG.error(
-                "[Continuous skepticism (Sherlock Protocol)] llama.cpp completion failed",
+                "llama.cpp completion failed",
                 extra={
                     "classname": self.__class__.__name__,
                     "function": "stream",
                     "system_section": "llm",
                     "error": str(exc),
                     "structured_message": "Inspect llama.cpp backend logs",
+                    "derived_message": "Review llama.cpp runtime output for additional details",
                 },
             )
             raise RuntimeError("llama.cpp completion failed") from exc

--- a/voice_agent/logging/__init__.py
+++ b/voice_agent/logging/__init__.py
@@ -22,11 +22,9 @@ LOG_SCHEMA_FIELDS = [
     "derived_message",
 ]
 
-SHERLOCK_PROMPT = """Continuous skepticism (Sherlock Protocol)\n* Could this change affect unexpected files/systems?\n* Any hidden dependencies or cascades?\n* What edge cases and failure modes are unhandled?\n* If stuck, work backward from the desired outcome."""
-
 
 class StructuredFormatter(logging.Formatter):
-    """Emit structured JSON logs plus the mandated human readable prompt."""
+    """Emit structured JSON logs with optional derived guidance lines."""
 
     def format(self, record: logging.LogRecord) -> str:
         payload: Dict[str, Any] = {field: getattr(record, field, None) for field in LOG_SCHEMA_FIELDS}
@@ -45,8 +43,8 @@ class StructuredFormatter(logging.Formatter):
         json_line = json.dumps(payload, ensure_ascii=False)
         derived = record.__dict__.get("derived_message")
         if derived:
-            return f"{json_line}\n{derived}\n{SHERLOCK_PROMPT}"
-        return f"{json_line}\n{SHERLOCK_PROMPT}"
+            return f"{json_line}\n{derived}"
+        return json_line
 
 
 def configure_logging(level: int = logging.INFO) -> None:

--- a/voice_agent/vad/silero.py
+++ b/voice_agent/vad/silero.py
@@ -156,7 +156,7 @@ class SileroVadStream(VadStream):
                     self._state = VadState.SPEECH
                     self._active_frames = 0
                     self._logger.info(
-                        "[Continuous skepticism (Sherlock Protocol)] Speech detected",
+                        "Speech detected",
                         extra={
                             "classname": self.__class__.__name__,
                             "function": "__iter__",
@@ -168,7 +168,7 @@ class SileroVadStream(VadStream):
                     self._state = VadState.SILENCE
                     self._inactive_frames = 0
                     self._logger.info(
-                        "[Continuous skepticism (Sherlock Protocol)] Speech ended",
+                        "Speech ended",
                         extra={
                             "classname": self.__class__.__name__,
                             "function": "__iter__",


### PR DESCRIPTION
## Summary
- replace the Sherlock prompt logging with neutral derived guidance output and align ASR/LLM/VAD log messages
- connect the `voice-agent run` command to the Smart-Turn orchestrator to drive ASR, LLM, and TTS playback with fallbacks
- refresh docs, scripts, and tests to describe and exercise the new conversational workflow

## Testing
- poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ed95d9cd98832b99c0745c725397a2