### PR TITLE
Enable Smart-Turn playback in CLI run

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,9 +6,10 @@ import numpy as np
 
 from typer.testing import CliRunner
 
-from voice_agent.cli.app import _download_file, app
+from voice_agent.cli.app import MissingModelError, _download_file, app
 from voice_agent.config import ConfigManager
-from voice_agent.asr import AsrEngine, AsrEvent
+from voice_agent.runtime import SmartTurnResult
+from voice_agent.vad import VadEvent, VadState
 
 runner = CliRunner()
 
@@ -148,10 +149,30 @@ def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
     ConfigManager(config_path=config_path)
 
     class DummyAudio:
-        samplerate = 16000
+        def __init__(self) -> None:
+            self.samplerate = 16000
 
         def record_loopback(self, seconds: float, input_device=None, output_device=None):
-            return np.zeros((160, 1), dtype=np.float32)
+            return np.zeros((1600, 1), dtype=np.float32)
+
+    class DummyOrchestrator:
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[np.ndarray], list[VadEvent]]] = []
+
+        def run(self, audio_frames, vad_stream):
+            frames = list(audio_frames)
+            events = list(vad_stream)
+            self.calls.append((frames, events))
+            return SmartTurnResult(
+                transcript="hi there",
+                response="hello back",
+                partials=("hi",),
+                confidences=(0.42,),
+                utterance_ms=900.0,
+                metrics={"asr.latency": 12.0},
+            )
+
+    orchestrator = DummyOrchestrator()
 
     with (
         mock.patch("voice_agent.cli.app.AudioIO", return_value=DummyAudio()),
@@ -160,7 +181,10 @@ def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
             side_effect=FileNotFoundError("missing model"),
         ),
         mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
-        mock.patch("voice_agent.cli.app.create_asr_engine", side_effect=RuntimeError("asr disabled")),
+        mock.patch(
+            "voice_agent.cli.app._create_smart_turn_orchestrator",
+            return_value=orchestrator,
+        ),
     ):
         result = runner.invoke(
             app,
@@ -169,9 +193,14 @@ def test_run_handles_missing_vad_model(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0
-    assert "Loopback turn 1 complete" in result.stdout
-    assert "Loopback session complete" in result.stdout
-    assert mock_visualizer.return_value.run_demo.called
+    assert "Assistant response: hello back" in result.stdout
+    assert "Smart-Turn session complete" in result.stdout
+    render_vad = mock_visualizer.return_value.render_vad
+    render_vad.assert_called_once()
+    assert len(orchestrator.calls) == 1
+    _, vad_events = orchestrator.calls[0]
+    assert vad_events[0].state is VadState.SPEECH
+    assert vad_events[-1].state is VadState.SILENCE
 
 
 def test_run_supports_multiple_turns(tmp_path: Path) -> None:
@@ -185,19 +214,42 @@ def test_run_supports_multiple_turns(tmp_path: Path) -> None:
         np.zeros((160, 1), dtype=np.float32),
     ]
 
-    class DummyAsr(AsrEngine):
-        def transcribe(self, audio_stream):  # type: ignore[override]
-            self.emit_final(AsrEvent(text="hi", timestamp=0.0, confidence=0.5))
-
     with (
         mock.patch("voice_agent.cli.app.AudioIO", return_value=dummy_audio),
-        mock.patch("voice_agent.cli.app.SileroVadStream.from_numpy", return_value=["vad"]),
-        mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
         mock.patch(
-            "voice_agent.cli.app.create_asr_engine",
-            side_effect=[DummyAsr(), DummyAsr()],
+            "voice_agent.cli.app.SileroVadStream.from_numpy",
+            side_effect=[
+                [
+                    VadEvent(state=VadState.SPEECH, confidence=1.0, timestamp=0.03),
+                    VadEvent(state=VadState.SILENCE, confidence=1.0, timestamp=0.5),
+                ],
+                [
+                    VadEvent(state=VadState.SPEECH, confidence=1.0, timestamp=0.03),
+                    VadEvent(state=VadState.SILENCE, confidence=1.0, timestamp=0.5),
+                ],
+            ],
         ),
+        mock.patch("voice_agent.cli.app.DotsVisualizer") as mock_visualizer,
+        mock.patch("voice_agent.cli.app._create_smart_turn_orchestrator") as mock_orchestrator,
     ):
+        mock_orchestrator.return_value.run.side_effect = [
+            SmartTurnResult(
+                transcript="hello",
+                response="world",
+                partials=("hello",),
+                confidences=(0.7,),
+                utterance_ms=800.0,
+                metrics={},
+            ),
+            SmartTurnResult(
+                transcript="second",
+                response="turn",
+                partials=("second",),
+                confidences=(0.6,),
+                utterance_ms=750.0,
+                metrics={},
+            ),
+        ]
         result = runner.invoke(
             app,
             ["run", "--turns", "2"],
@@ -208,3 +260,37 @@ def test_run_supports_multiple_turns(tmp_path: Path) -> None:
     assert dummy_audio.record_loopback.call_count == 2
     assert result.stdout.count("Loopback turn") == 2
     assert mock_visualizer.return_value.render_vad.call_count == 2
+    assert mock_orchestrator.return_value.run.call_count == 2
+
+
+def test_run_reports_missing_asr_assets(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    ConfigManager(config_path=config_path)
+
+    class DummyAudio:
+        def __init__(self) -> None:
+            self.samplerate = 16000
+
+        def record_loopback(self, seconds: float, input_device=None, output_device=None):
+            return np.zeros((1, 1), dtype=np.float32)
+
+    with (
+        mock.patch("voice_agent.cli.app.AudioIO", return_value=DummyAudio()),
+        mock.patch(
+            "voice_agent.cli.app._create_smart_turn_orchestrator",
+            side_effect=MissingModelError(
+                "ASR",
+                Path("assets/asr/faster-whisper-base"),
+                "voice-agent models pull asr/faster-whisper-base",
+            ),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["run", "--turns", "1"],
+            env={"VOICE_AGENT_CONFIG": str(config_path)},
+        )
+
+    assert result.exit_code == 1
+    assert "Error: ASR assets missing" in result.stdout
+    assert "Hint: voice-agent models pull asr/faster-whisper-base" in result.stdout

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -7,7 +7,7 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 import numpy as np
 import requests
@@ -19,7 +19,7 @@ from voice_agent.benchmarks import (
     measure_llm_latency,
     measure_tts_latency,
 )
-from voice_agent.asr import AsrEvent, create_asr_engine
+from voice_agent.asr import create_asr_engine
 from voice_agent.audio import AudioIO
 from voice_agent.cli.visualizer import DotsVisualizer
 from voice_agent.config import ConfigManager
@@ -27,7 +27,8 @@ from voice_agent.llm import LlmConfig as RuntimeLlmConfig, create_llm_engine
 from voice_agent.logging import configure_logging, get_logger
 from voice_agent.telemetry import TelemetryClient
 from voice_agent.tts import KittenTTS, load_voice_inventory
-from voice_agent.vad import SileroVadError, SileroVadStream
+from voice_agent.vad import SileroVadError, SileroVadStream, VadEvent, VadState
+from voice_agent.runtime import SmartTurnError, SmartTurnOrchestrator
 
 app = typer.Typer(add_completion=False, help="Cross-platform voice agent runtime")
 profile_app = typer.Typer(help="Manage configuration profiles")
@@ -54,6 +55,102 @@ def _config_manager(config_path: Optional[Path]) -> ConfigManager:
     return ConfigManager(config_path=config_path) if config_path else ConfigManager()
 
 
+class MissingModelError(RuntimeError):
+    """Raised when a required model asset could not be located."""
+
+    def __init__(self, component: str, path: Path, suggestion: str | None = None) -> None:
+        super().__init__(f"{component} assets missing at {path}")
+        self.component = component
+        self.path = path
+        self.suggestion = suggestion
+
+
+class _SmartTurnTtsAdapter:
+    """Adapter that routes Kitten TTS synthesis through the configured audio device."""
+
+    def __init__(self, tts: KittenTTS, output_device: Optional[str]) -> None:
+        self._tts = tts
+        self._output_device = output_device
+
+    def speak(self, text: str, chunk_config: Dict[str, int]) -> None:
+        for chunk in self._tts.synthesize(text, chunk_config):
+            self._tts.audio.playback(chunk, output_device=self._output_device)
+
+
+def _iter_audio_frames(audio: np.ndarray, frame_size: int = 512) -> Iterator[np.ndarray]:
+    """Yield contiguous frames from the recorded audio for Smart-Turn processing."""
+
+    flattened = np.ascontiguousarray(audio, dtype=np.float32).reshape(-1)
+    if flattened.size == 0:
+        return
+    for start in range(0, flattened.size, frame_size):
+        yield flattened[start : start + frame_size]
+
+
+def _fallback_vad_stream(duration_s: float) -> Iterator[VadEvent]:
+    """Return a minimal VAD stream when Silero assets are unavailable."""
+
+    yield VadEvent(state=VadState.SPEECH, confidence=1.0, timestamp=0.0)
+    yield VadEvent(state=VadState.SILENCE, confidence=1.0, timestamp=max(0.0, duration_s))
+
+
+def _create_smart_turn_orchestrator(
+    profile: "ProfileConfig",
+    audio: AudioIO,
+    output_device: Optional[str],
+) -> SmartTurnOrchestrator:
+    """Initialise the Smart-Turn orchestrator for the active profile."""
+
+    telemetry = TelemetryClient()
+
+    try:
+        asr_engine = create_asr_engine(profile.asr)
+    except RuntimeError as exc:
+        raise MissingModelError(
+            "ASR",
+            profile.asr.model_path,
+            suggestion=f"voice-agent models pull asr/{profile.asr.model_path.name}",
+        ) from exc
+
+    runtime_config = RuntimeLlmConfig(
+        model_path=profile.llm.model_path,
+        temperature=profile.llm.temperature,
+        top_p=profile.llm.top_p,
+        repeat_penalty=profile.llm.repeat_penalty,
+        context_window=profile.llm.context_window,
+    )
+
+    try:
+        llm_engine = create_llm_engine(runtime_config)
+    except FileNotFoundError as exc:
+        raise MissingModelError(
+            "LLM",
+            profile.llm.model_path,
+            suggestion=f"voice-agent models pull llm/{profile.llm.model_path.name}",
+        ) from exc
+
+    try:
+        kitten = KittenTTS(profile.tts.model_dir, profile.tts.voice_id)
+    except FileNotFoundError as exc:
+        raise MissingModelError(
+            "TTS",
+            profile.tts.model_dir,
+            suggestion="voice-agent models pull tts/kitten-nano-0.2",
+        ) from exc
+
+    tts_engine = _SmartTurnTtsAdapter(kitten, output_device)
+
+    return SmartTurnOrchestrator(
+        asr_engine=asr_engine,
+        llm_engine=llm_engine,
+        tts_engine=tts_engine,
+        turn_config=profile.turn,
+        tts_config=profile.tts,
+        sample_rate=audio.samplerate,
+        telemetry=telemetry,
+    )
+
+
 @app.command()
 def run(
     config_path: Optional[Path] = typer.Option(None, "--config-path", help="Override configuration path"),
@@ -76,7 +173,25 @@ def run(
     profile = config.active()
     vad_model_path = profile.vad.model_path.expanduser()
     max_turns = None if turns == 0 else turns
-    typer.echo("Starting loopback session. Press Ctrl+C to exit.")
+    try:
+        orchestrator = _create_smart_turn_orchestrator(profile, audio, output_device)
+    except MissingModelError as exc:
+        _LOG.error(
+            "Smart-Turn initialisation failed",
+            extra={
+                "classname": "CLI",
+                "function": "run",
+                "system_section": exc.component.lower(),
+                "error": str(exc),
+                "derived_message": "Quality review: Required runtime assets missing for Smart-Turn",
+            },
+        )
+        typer.echo(f"Error: {exc}")
+        if exc.suggestion:
+            typer.echo(f"Hint: {exc.suggestion}")
+        raise typer.Exit(code=1) from exc
+
+    typer.echo("Starting Smart-Turn session. Press Ctrl+C to exit.")
     completed_turns = 0
 
     try:
@@ -98,6 +213,7 @@ def run(
                     release_level=profile.vad.release_level,
                     sensitivity=profile.vad.sensitivity,
                 )
+                vad_events = list(vad_stream)
             except FileNotFoundError as exc:
                 _LOG.warning(
                     "VAD model missing",
@@ -106,10 +222,10 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "Quality review: Silero VAD assets unavailable; switching to RMS visualiser",
+                        "derived_message": "Quality review: Silero VAD assets unavailable; using synthetic VAD stream",
                     },
                 )
-                visualizer.run_demo(data)
+                vad_events = list(_fallback_vad_stream(data.size / float(audio.samplerate)))
             except SileroVadError as exc:
                 _LOG.error(
                     "VAD initialisation failed",
@@ -118,62 +234,47 @@ def run(
                         "function": "run",
                         "system_section": "vad",
                         "error": str(exc),
-                        "derived_message": "Quality review: VAD backend error; reverting to RMS visualiser",
+                        "derived_message": "Quality review: VAD backend error; using synthetic VAD stream",
                     },
                 )
-                visualizer.run_demo(data)
-            else:
-                visualizer.render_vad(vad_stream, fallback_audio=data)
+                vad_events = list(_fallback_vad_stream(data.size / float(audio.samplerate)))
+
+            visualizer.render_vad(vad_events, fallback_audio=data)
 
             try:
-                asr_engine = create_asr_engine(profile.asr)
-            except RuntimeError as exc:
-                _LOG.warning(
-                    "ASR backend unavailable; continuing without transcription",
+                result = orchestrator.run(
+                    audio_frames=_iter_audio_frames(data),
+                    vad_stream=iter(vad_events),
+                )
+            except SmartTurnError as exc:
+                _LOG.error(
+                    "Smart-Turn execution failed",
                     extra={
                         "classname": "CLI",
                         "function": "run",
-                        "system_section": "asr",
+                        "system_section": "smart_turn",
                         "error": str(exc),
-                        "structured_message": "ASR backend unavailable",
-                        "derived_message": "Quality review: Investigate ASR configuration before enabling LLM+TTS turn",
+                        "derived_message": "Quality review: Investigate Smart-Turn orchestration inputs",
                     },
                 )
+                typer.echo(f"Smart-Turn failed: {exc}")
             else:
-                asr_partials: list[str] = []
-                asr_finals: list[AsrEvent] = []
-                asr_confidence: list[float] = []
-
-                asr_engine.on_partial(lambda event: asr_partials.append(event.text))
-                asr_engine.on_final(asr_finals.append)
-                asr_engine.on_confidence(lambda value: asr_confidence.append(value))
-                audio_bytes = [np.ascontiguousarray(data, dtype=np.float32).reshape(-1).tobytes()]
-                try:
-                    asr_engine.transcribe(audio_bytes)
-                except Exception as exc:  # pragma: no cover - backend specific failures
-                    _LOG.error(
-                        "ASR transcription failed",
-                        extra={
-                            "classname": "CLI",
-                            "function": "run",
-                            "system_section": "asr",
-                            "error": str(exc),
-                            "structured_message": "ASR transcription failed",
-                        },
+                typer.echo(f"User transcript: {result.transcript}")
+                typer.echo(f"Assistant response: {result.response}")
+                if result.confidences:
+                    typer.echo(f"ASR confidence: {result.confidences[-1]:.2f}")
+                if result.metrics:
+                    metrics = ", ".join(
+                        f"{name}={value:.1f}ms" if name.endswith("latency") else f"{name}={value}"
+                        for name, value in sorted(result.metrics.items())
                     )
-                else:
-                    if asr_partials:
-                        visualizer.render_partial(asr_partials)
-                    if asr_finals:
-                        typer.echo(f"Final transcript: {asr_finals[-1].text}")
-                    if asr_confidence:
-                        typer.echo(f"Language confidence: {asr_confidence[-1]:.2f}")
+                    typer.echo(f"Turn metrics: {metrics}")
 
             typer.echo(f"Loopback turn {completed_turns} complete")
     except KeyboardInterrupt:
-        typer.echo("\nLoopback interrupted by user")
+        typer.echo("\nSmart-Turn session interrupted by user")
 
-    typer.echo("Loopback session complete")
+    typer.echo("Smart-Turn session complete")
 
 
 @bench_app.command("llm")


### PR DESCRIPTION
## Summary
- hook the CLI `run` command into the Smart-Turn orchestrator so user turns are transcribed, answered, and spoken back
- add graceful fallbacks for missing VAD assets, propagate actionable model download hints, and surface Smart-Turn metrics in the console
- update CLI regression tests to exercise the new orchestration flow, fallback VAD stream, and missing-asset messaging

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ed96d02ea0832bb1e51d5b7122716d