### PR TITLE
Handle incomplete Faster-Whisper assets

### DIFF
--- a/task.md
+++ b/task.md
@@ -25,3 +25,4 @@
 - [x] Replace Sherlock protocol references with the new quality review checklist across tooling.
 - [x] Extend CLI loopback run command to support multi-turn sessions.
 - [x] Add desktop dev shell script with workspace validation for the Tauri frontend.
+- [x] Detect and repair incomplete Faster-Whisper asset directories during initialisation.

--- a/tests/test_asr_engines.py
+++ b/tests/test_asr_engines.py
@@ -122,6 +122,51 @@ def test_faster_whisper_engine_downloads_missing_alias(tmp_path: Path, monkeypat
     assert created["download_options"] == {"download_root": str(target_dir.resolve())}
 
 
+def test_faster_whisper_engine_recovers_incomplete_assets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created: dict[str, object] = {}
+
+    class DummyModel:
+        def __init__(
+            self,
+            model_path: str,
+            device: str,
+            compute_type: str,
+            download_options: dict | None = None,
+        ) -> None:
+            created.update(
+                {
+                    "model_path": model_path,
+                    "device": device,
+                    "compute_type": compute_type,
+                    "download_options": download_options,
+                }
+            )
+
+        def transcribe(self, audio: np.ndarray, language: str, beam_size: int):  # pragma: no cover - not executed
+            raise AssertionError("transcribe should not be invoked in constructor test")
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", types.SimpleNamespace(WhisperModel=DummyModel))
+
+    target_dir = tmp_path / "faster-whisper-base"
+    target_dir.mkdir()
+    (target_dir / "placeholder.txt").write_text("partial download")
+
+    config = AsrConfig.model_validate(
+        {
+            "asr_backend": "faster-whisper",
+            "asr_model": str(target_dir),
+            "asr_device": "cpu",
+        }
+    )
+
+    create_asr_engine(config)
+
+    assert created["model_path"] == "base"
+    assert created["download_options"] == {"download_root": str(target_dir.resolve())}
+
+
 def test_mlx_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyModel:
         def __init__(self, model_path: str, device: str) -> None:  # noqa: ARG002

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -76,8 +76,9 @@ class FasterWhisperEngine(AsrEngine):
         download_options: Dict[str, str] | None = None
         model_location: str | Path = resolved_path
 
+        pretrained_name = _resolve_pretrained_name(resolved_path)
+
         if not resolved_path.exists():
-            pretrained_name = _resolve_pretrained_name(resolved_path)
             if pretrained_name:
                 resolved_path.mkdir(parents=True, exist_ok=True)
                 download_options = {"download_root": str(resolved_path)}
@@ -115,6 +116,46 @@ class FasterWhisperEngine(AsrEngine):
                 raise RuntimeError(
                     f"{error_message}. Provide a valid Faster-Whisper model path or use a supported alias"
                 )
+        elif resolved_path.is_dir():
+            has_model_binary = any(resolved_path.glob("*.bin"))
+            if not has_model_binary:
+                if pretrained_name:
+                    download_options = {"download_root": str(resolved_path)}
+                    model_location = pretrained_name
+                    _LOG.warning(
+                        "Re-downloading incomplete Faster-Whisper assets",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "__init__",
+                            "system_section": "asr",
+                            "structured_message": str(
+                                {
+                                    "pretrained": pretrained_name,
+                                    "destination": str(resolved_path),
+                                    "reason": "missing model binaries",
+                                }
+                            ),
+                            "derived_message": "Quality review: Faster-Whisper asset directory incomplete; re-downloading pretrained model",
+                        },
+                    )
+                else:
+                    error_message = (
+                        f"Model assets incomplete at {resolved_path}; expected model binary files"
+                    )
+                    _LOG.error(
+                        "Failed to load Faster-Whisper model",
+                        extra={
+                            "classname": self.__class__.__name__,
+                            "function": "__init__",
+                            "system_section": "asr",
+                            "error": error_message,
+                            "structured_message": "Remove the directory or provide a valid Faster-Whisper model path",
+                            "derived_message": "Quality review: Incomplete ASR assets detected without a known alias",
+                        },
+                    )
+                    raise RuntimeError(
+                        f"{error_message}. Provide a valid Faster-Whisper model path or use a supported alias"
+                    )
 
         try:
             if download_options is not None:

--- a/voice_agent/cli/app.py
+++ b/voice_agent/cli/app.py
@@ -7,7 +7,7 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, Optional, TYPE_CHECKING
 
 import numpy as np
 import requests
@@ -29,6 +29,9 @@ from voice_agent.telemetry import TelemetryClient
 from voice_agent.tts import KittenTTS, load_voice_inventory
 from voice_agent.vad import SileroVadError, SileroVadStream, VadEvent, VadState
 from voice_agent.runtime import SmartTurnError, SmartTurnOrchestrator
+
+if TYPE_CHECKING:
+    from voice_agent.config.models import ProfileConfig
 
 app = typer.Typer(add_completion=False, help="Cross-platform voice agent runtime")
 profile_app = typer.Typer(help="Manage configuration profiles")


### PR DESCRIPTION
## Summary
- detect and re-download incomplete Faster-Whisper asset directories with structured logging
- add regression coverage exercising recovery from partial asset downloads
- update the project task tracker and ensure CLI type hints satisfy linting

## Testing
- poetry run ruff check
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed9c753f4c832b858d169de7667b3e