### PR TITLE
Fix Faster-Whisper download root usage

### DIFF
--- a/task.md
+++ b/task.md
@@ -26,3 +26,4 @@
 - [x] Extend CLI loopback run command to support multi-turn sessions.
 - [x] Add desktop dev shell script with workspace validation for the Tauri frontend.
 - [x] Detect and repair incomplete Faster-Whisper asset directories during initialisation.
+- [x] Fix Faster-Whisper download root handling for Hugging Face-managed assets.

--- a/tests/test_asr_engines.py
+++ b/tests/test_asr_engines.py
@@ -29,9 +29,9 @@ def test_faster_whisper_engine_transcribes(tmp_path: Path, monkeypatch: pytest.M
             model_path: str,
             device: str,
             compute_type: str,
-            download_options: dict | None = None,
+            download_root: str | None = None,
         ) -> None:  # noqa: ARG002
-            self.calls = [(model_path, device, compute_type, download_options)]
+            self.calls = [(model_path, device, compute_type, download_root)]
 
         def transcribe(self, audio: np.ndarray, language: str, beam_size: int):  # noqa: ARG002
             assert isinstance(audio, np.ndarray)
@@ -91,14 +91,14 @@ def test_faster_whisper_engine_downloads_missing_alias(tmp_path: Path, monkeypat
             model_path: str,
             device: str,
             compute_type: str,
-            download_options: dict | None = None,
+            download_root: str | None = None,
         ) -> None:
             created.update(
                 {
                     "model_path": model_path,
                     "device": device,
                     "compute_type": compute_type,
-                    "download_options": download_options,
+                    "download_root": download_root,
                 }
             )
 
@@ -119,7 +119,7 @@ def test_faster_whisper_engine_downloads_missing_alias(tmp_path: Path, monkeypat
     create_asr_engine(config)
 
     assert created["model_path"] == "base"
-    assert created["download_options"] == {"download_root": str(target_dir.resolve())}
+    assert created["download_root"] == str(target_dir.resolve())
 
 
 def test_faster_whisper_engine_recovers_incomplete_assets(
@@ -133,14 +133,14 @@ def test_faster_whisper_engine_recovers_incomplete_assets(
             model_path: str,
             device: str,
             compute_type: str,
-            download_options: dict | None = None,
+            download_root: str | None = None,
         ) -> None:
             created.update(
                 {
                     "model_path": model_path,
                     "device": device,
                     "compute_type": compute_type,
-                    "download_options": download_options,
+                    "download_root": download_root,
                 }
             )
 
@@ -164,7 +164,7 @@ def test_faster_whisper_engine_recovers_incomplete_assets(
     create_asr_engine(config)
 
     assert created["model_path"] == "base"
-    assert created["download_options"] == {"download_root": str(target_dir.resolve())}
+    assert created["download_root"] == str(target_dir.resolve())
 
 
 def test_mlx_whisper_engine_transcribes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/voice_agent/asr/faster_whisper.py
+++ b/voice_agent/asr/faster_whisper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Iterable
 
 import numpy as np
 
@@ -73,7 +73,7 @@ class FasterWhisperEngine(AsrEngine):
         resolved_path = resolved_path.resolve()
 
         compute = compute_type or ("int8" if device == "cpu" else "float16")
-        download_options: Dict[str, str] | None = None
+        download_root: str | None = None
         model_location: str | Path = resolved_path
 
         pretrained_name = _resolve_pretrained_name(resolved_path)
@@ -81,7 +81,7 @@ class FasterWhisperEngine(AsrEngine):
         if not resolved_path.exists():
             if pretrained_name:
                 resolved_path.mkdir(parents=True, exist_ok=True)
-                download_options = {"download_root": str(resolved_path)}
+                download_root = str(resolved_path)
                 model_location = pretrained_name
                 _LOG.info(
                     "Downloading Faster-Whisper model",
@@ -120,7 +120,7 @@ class FasterWhisperEngine(AsrEngine):
             has_model_binary = any(resolved_path.glob("*.bin"))
             if not has_model_binary:
                 if pretrained_name:
-                    download_options = {"download_root": str(resolved_path)}
+                    download_root = str(resolved_path)
                     model_location = pretrained_name
                     _LOG.warning(
                         "Re-downloading incomplete Faster-Whisper assets",
@@ -158,12 +158,12 @@ class FasterWhisperEngine(AsrEngine):
                     )
 
         try:
-            if download_options is not None:
+            if download_root is not None:
                 self._model = WhisperModel(
                     model_location,
                     device=device,
                     compute_type=compute,
-                    download_options=download_options,
+                    download_root=download_root,
                 )
             else:
                 self._model = WhisperModel(str(model_location), device=device, compute_type=compute)


### PR DESCRIPTION
## Summary
- update the Faster-Whisper engine to pass download_root directly to WhisperModel
- refresh ASR engine tests to reflect the new constructor signature and expectations
- record the completed fix in task tracking

## Testing
- poetry run pytest
- poetry run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68edb6448838832b9bf38e79676404d8