### PR TITLE
Handle unsupported llama.cpp architectures

### DIFF
--- a/task.md
+++ b/task.md
@@ -27,3 +27,4 @@
 - [x] Add desktop dev shell script with workspace validation for the Tauri frontend.
 - [x] Detect and repair incomplete Faster-Whisper asset directories during initialisation.
 - [x] Fix Faster-Whisper download root handling for Hugging Face-managed assets.
+- [x] Surface unsupported llama.cpp GGUF architecture guidance during model load.

--- a/tests/test_llm_llama_cpp.py
+++ b/tests/test_llm_llama_cpp.py
@@ -70,3 +70,23 @@ def test_missing_model_raises(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError):
         create_llm_engine(config)
+
+
+def test_unknown_architecture_error(tmp_path: Path, mocker) -> None:
+    model_path = tmp_path / "model.gguf"
+    _write_dummy_model(model_path)
+
+    exc_message = (
+        "Failed to load model from file: assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
+        "\nerror loading model architecture: unknown model architecture: 'lfm2'"
+    )
+
+    mock_llama = mocker.Mock(side_effect=ValueError(exc_message))
+
+    config = LlmConfig(model_path=model_path)
+
+    with mock.patch.dict(sys.modules, {"llama_cpp": SimpleNamespace(Llama=mock_llama)}):
+        with pytest.raises(RuntimeError) as excinfo:
+            create_llm_engine(config)
+
+    assert "Unsupported GGUF architecture 'lfm2'" in str(excinfo.value)

--- a/voice_agent/llm/llama_cpp.py
+++ b/voice_agent/llm/llama_cpp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator
 
 if TYPE_CHECKING:  # pragma: no cover - import used for typing only
@@ -63,7 +64,36 @@ class LlamaCppEngine(LlmEngine):
         )
         from llama_cpp import Llama
 
-        return Llama(**init_kwargs)
+        try:
+            return Llama(**init_kwargs)
+        except ValueError as exc:
+            error_message = str(exc)
+            architecture = _extract_unknown_architecture(error_message)
+            if architecture:
+                guidance = (
+                    f"Unsupported GGUF architecture '{architecture}' detected. "
+                    "Upgrade llama.cpp-python to a build that recognises this architecture "
+                    "or choose a model converted with a supported base architecture."
+                )
+            else:
+                guidance = "llama.cpp failed to load the GGUF model. Verify compatibility."
+
+            derived_message = (
+                "[Continuous skepticism (Sherlock Protocol)] "
+                "Investigate llama.cpp GGUF compatibility failure"
+            )
+            _LOG.error(
+                "Failed to load llama.cpp model",
+                extra={
+                    "classname": self.__class__.__name__,
+                    "function": "_initialise_model",
+                    "system_section": "llm",
+                    "error": error_message,
+                    "structured_message": guidance,
+                    "derived_message": derived_message,
+                },
+            )
+            raise RuntimeError(guidance) from exc
 
     def stream(self, prompt: str, *, max_tokens: int | None = None) -> Iterable[str]:
         sampling = {
@@ -122,3 +152,12 @@ def create_llm_engine(config: LlmConfig) -> LlmEngine:
     """Instantiate an :class:`LlamaCppEngine` for the provided config."""
 
     return LlamaCppEngine(config)
+
+
+def _extract_unknown_architecture(message: str) -> str | None:
+    """Return the architecture referenced in a llama.cpp unknown architecture error."""
+
+    match = re.search(r"unknown model architecture: '([^']+)'", message)
+    if match:
+        return match.group(1)
+    return None


### PR DESCRIPTION
## Summary
- add defensive handling for llama.cpp ValueError when encountering unsupported GGUF architectures and emit structured guidance
- extract the architecture name from backend error text for improved error messaging and logging
- extend tests and task tracker to cover the unsupported architecture scenario

## Testing
- poetry run ruff check voice_agent/llm/llama_cpp.py tests/test_llm_llama_cpp.py
- poetry run pytest tests/test_llm_llama_cpp.py

------
https://chatgpt.com/codex/tasks/task_e_68edbbbc99f8832b95db31a22b823c7e