### PR TITLE
Switch default llama.cpp profile to TinyLlama

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 
 ### Bootstrap
 
-Use the provided script to set up dependencies and fetch baseline models (LFM2-350M + Kitten TTS assets):
+Use the provided script to set up dependencies and fetch baseline models (TinyLlama 1.1B Chat + Kitten TTS assets):
 
 ```bash
 ./scripts/bootstrap.sh
@@ -98,4 +98,4 @@ See [task.md](task.md) for the tracked epics and outstanding work (Silero VAD, W
 
 ## Licensing
 
-This project is distributed under the Apache-2.0 license. Third-party model licenses (LiquidAI LFM2 GGUF, Kitten TTS Nano 0.2) must be reviewed before redistribution.
+This project is distributed under the Apache-2.0 license. Third-party model licenses (TinyLlama 1.1B Chat GGUF, Kitten TTS Nano 0.2) must be reviewed before redistribution.

--- a/config/config.toml
+++ b/config/config.toml
@@ -6,7 +6,7 @@ asr_model = "assets/asr/faster-whisper-base"
 asr_device = "cpu"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.7
 llm_top_p = 0.9
@@ -36,7 +36,7 @@ asr_model = "assets/asr/mlx-whisper-small"
 asr_device = "mps"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-700M-GGUF/LFM2-700M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.8
 llm_top_p = 0.9

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ASSETS_DIR="$PROJECT_ROOT/assets"
-LLM_DIR="$ASSETS_DIR/llm/LiquidAI/LFM2-350M-GGUF"
+LLM_DIR="$ASSETS_DIR/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF"
 TTS_DIR="$ASSETS_DIR/tts/kitten-tts"
 
 python_bin=${PYTHON:-python3}
@@ -20,10 +20,10 @@ poetry install --with dev
 
 mkdir -p "$LLM_DIR" "$TTS_DIR"
 
-LLM_FILE="$LLM_DIR/LFM2-350M-Q4_K_M.gguf"
+LLM_FILE="$LLM_DIR/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 if [ ! -f "$LLM_FILE" ]; then
-  echo "Downloading LFM2-350M GGUF (Q4_K_M)..."
-  curl -L "https://huggingface.co/LiquidAI/LFM2-350M-GGUF/resolve/main/LFM2-350M-Q4_K_M.gguf" -o "$LLM_FILE"
+  echo "Downloading TinyLlama 1.1B Chat GGUF (Q4_K_M)..."
+  curl -L "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf" -o "$LLM_FILE"
 fi
 
 if [ ! -f "$TTS_DIR/kitten_tts_nano_v0_2.onnx" ]; then

--- a/task.md
+++ b/task.md
@@ -28,3 +28,4 @@
 - [x] Detect and repair incomplete Faster-Whisper asset directories during initialisation.
 - [x] Fix Faster-Whisper download root handling for Hugging Face-managed assets.
 - [x] Surface unsupported llama.cpp GGUF architecture guidance during model load.
+- [x] Switch default llama.cpp profiles to TinyLlama 1.1B Chat GGUF for compatibility.

--- a/tests/test_llm_llama_cpp.py
+++ b/tests/test_llm_llama_cpp.py
@@ -77,8 +77,8 @@ def test_unknown_architecture_error(tmp_path: Path, mocker) -> None:
     _write_dummy_model(model_path)
 
     exc_message = (
-        "Failed to load model from file: assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
-        "\nerror loading model architecture: unknown model architecture: 'lfm2'"
+        "Failed to load model from file: assets/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/"
+        "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf\nerror loading model architecture: unknown model architecture: 'lfm2'"
     )
 
     mock_llama = mocker.Mock(side_effect=ValueError(exc_message))

--- a/voice_agent/config/default_config.toml
+++ b/voice_agent/config/default_config.toml
@@ -6,7 +6,7 @@ asr_model = "assets/asr/faster-whisper-base"
 asr_device = "cpu"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.7
 llm_top_p = 0.9
@@ -36,7 +36,7 @@ asr_model = "assets/asr/mlx-whisper-small"
 asr_device = "mps"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-700M-GGUF/LFM2-700M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.8
 llm_top_p = 0.9

--- a/voice_agent/models/registry.py
+++ b/voice_agent/models/registry.py
@@ -20,19 +20,12 @@ class ModelEntry:
 
 
 MODEL_REGISTRY: Dict[str, ModelEntry] = {
-    "llm/LiquidAI/LFM2-350M-GGUF": ModelEntry(
-        model_id="llm/LiquidAI/LFM2-350M-GGUF",
-        filename="LFM2-350M-Q4_K_M.gguf",
-        size_mb=356.7,
-        sha256="placeholder-sha256-350m",
-        description="LiquidAI LFM2 350M quantized GGUF",
-    ),
-    "llm/LiquidAI/LFM2-700M-GGUF": ModelEntry(
-        model_id="llm/LiquidAI/LFM2-700M-GGUF",
-        filename="LFM2-700M-Q4_K_M.gguf",
-        size_mb=702.1,
-        sha256="placeholder-sha256-700m",
-        description="LiquidAI LFM2 700M quantized GGUF",
+    "llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF": ModelEntry(
+        model_id="llm/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        filename="tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
+        size_mb=637.9,
+        sha256="placeholder-sha256-tinyllama-q4km",
+        description="TinyLlama 1.1B Chat Q4_K_M quantized GGUF",
     ),
     "tts/kitten-nano-0.2/onnx": ModelEntry(
         model_id="tts/kitten-nano-0.2/onnx",


### PR DESCRIPTION
## Summary
- update the default llama.cpp profile assets to TinyLlama 1.1B Chat GGUF so the bundled configuration uses a supported architecture
- refresh the bootstrap script, registry entry, and documentation to download and describe the new model
- align tests and task tracking with the TinyLlama asset path

## Testing
- poetry run pytest
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68edc1400450832bbe7ea0cd7f8cd0ee