### PR TITLE
Improve llama.cpp GGUF architecture guidance

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,5 +1,9 @@
 # Project Tasks
 
+- [x] Investigate llama.cpp LiquidAI LFM2 model load failure and confirm reproduction steps.
+- [x] Implement compatibility handling or guidance for unsupported GGUF architectures in llama.cpp engine.
+- [x] Verify regression coverage and run project test suite after llama.cpp compatibility fixes.
+
 - [x] Scaffold Python project with Poetry, pyproject, and package structure.
 - [x] Implement structured logging with quality review prompts.
 - [x] Add configuration management with profiles and asset validation.

--- a/tests/test_llm_llama_cpp.py
+++ b/tests/test_llm_llama_cpp.py
@@ -1,4 +1,5 @@
 import sys
+import struct
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -8,8 +9,20 @@ import pytest
 from voice_agent.llm import LlmConfig, LlamaCppEngine, create_llm_engine
 
 
-def _write_dummy_model(path: Path) -> None:
-    path.write_bytes(b"gguf")
+def _write_dummy_model(path: Path, architecture: str = "llama") -> None:
+    key = b"general.architecture"
+    value = architecture.encode("utf-8")
+
+    with path.open("wb") as handle:
+        handle.write(b"GGUF")
+        handle.write(struct.pack("<I", 3))  # version
+        handle.write(struct.pack("<Q", 0))  # tensor_count
+        handle.write(struct.pack("<Q", 1))  # kv_count
+        handle.write(struct.pack("<Q", len(key)))
+        handle.write(key)
+        handle.write(struct.pack("<I", 8))  # string type
+        handle.write(struct.pack("<Q", len(value)))
+        handle.write(value)
 
 
 def test_create_engine_loads_model(tmp_path: Path, mocker) -> None:
@@ -74,7 +87,7 @@ def test_missing_model_raises(tmp_path: Path) -> None:
 
 def test_unknown_architecture_error(tmp_path: Path, mocker) -> None:
     model_path = tmp_path / "model.gguf"
-    _write_dummy_model(model_path)
+    _write_dummy_model(model_path, architecture="lfm2")
 
     exc_message = (
         "Failed to load model from file: assets/llm/LiquidAI/LFM2-350M-GGUF/"
@@ -89,4 +102,23 @@ def test_unknown_architecture_error(tmp_path: Path, mocker) -> None:
         with pytest.raises(RuntimeError) as excinfo:
             create_llm_engine(config)
 
-    assert "Unsupported GGUF architecture 'lfm2'" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "LiquidAI LFM2 GGUF models require a llama.cpp build with Liquid Fourier Mamba support." in message
+
+
+def test_unknown_architecture_inferred_from_metadata(tmp_path: Path, mocker) -> None:
+    model_path = tmp_path / "model.gguf"
+    _write_dummy_model(model_path, architecture="lfm2")
+
+    exc_message = "Failed to load model from file: some/path/LFM2-350M-Q4_K_M.gguf"
+
+    mock_llama = mocker.Mock(side_effect=ValueError(exc_message))
+
+    config = LlmConfig(model_path=model_path)
+
+    with mock.patch.dict(sys.modules, {"llama_cpp": SimpleNamespace(Llama=mock_llama)}):
+        with pytest.raises(RuntimeError) as excinfo:
+            create_llm_engine(config)
+
+    message = str(excinfo.value)
+    assert "LiquidAI LFM2 GGUF models require a llama.cpp build with Liquid Fourier Mamba support." in message

--- a/voice_agent/llm/gguf_metadata.py
+++ b/voice_agent/llm/gguf_metadata.py
@@ -1,0 +1,134 @@
+"""Utilities for reading GGUF metadata required by the llama.cpp runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import BinaryIO
+
+_GGUF_MAGIC = b"GGUF"
+
+# GGUF metadata value type identifiers. The numeric values match the enum in
+# `gguf/constants.py` from the upstream llama.cpp project. Only the cases we
+# need to skip or parse are implemented here to keep the dependency surface
+# small.
+_TYPE_UINT8 = 0
+_TYPE_INT8 = 1
+_TYPE_UINT16 = 2
+_TYPE_INT16 = 3
+_TYPE_UINT32 = 4
+_TYPE_INT32 = 5
+_TYPE_FLOAT32 = 6
+_TYPE_BOOL = 7
+_TYPE_STRING = 8
+_TYPE_ARRAY = 9
+_TYPE_UINT64 = 10
+_TYPE_INT64 = 11
+_TYPE_FLOAT64 = 12
+
+_SCALAR_BYTE_SIZES: dict[int, int] = {
+    _TYPE_UINT8: 1,
+    _TYPE_INT8: 1,
+    _TYPE_UINT16: 2,
+    _TYPE_INT16: 2,
+    _TYPE_UINT32: 4,
+    _TYPE_INT32: 4,
+    _TYPE_FLOAT32: 4,
+    _TYPE_BOOL: 1,
+    _TYPE_UINT64: 8,
+    _TYPE_INT64: 8,
+    _TYPE_FLOAT64: 8,
+}
+
+
+def read_general_architecture(path: Path) -> str | None:
+    """Return the GGUF ``general.architecture`` value if present.
+
+    The parser focuses on the minimal subset of GGUF needed to reach metadata
+    entries without introducing an additional runtime dependency on the full
+    gguf Python package.
+    """
+
+    try:
+        with path.open("rb") as handle:
+            return _read_general_architecture_from_stream(handle)
+    except OSError:
+        return None
+
+
+def _read_general_architecture_from_stream(handle: BinaryIO) -> str | None:
+    if handle.read(len(_GGUF_MAGIC)) != _GGUF_MAGIC:
+        return None
+
+    # GGUF header layout:
+    # uint32 version, uint64 tensor_count, uint64 kv_count
+    version_bytes = handle.read(4)
+    if len(version_bytes) != 4:
+        return None
+
+    tensor_count_bytes = handle.read(8)
+    kv_count_bytes = handle.read(8)
+    if len(tensor_count_bytes) != 8 or len(kv_count_bytes) != 8:
+        return None
+
+    kv_count = int.from_bytes(kv_count_bytes, "little", signed=False)
+
+    for _ in range(kv_count):
+        key_length_bytes = handle.read(8)
+        if len(key_length_bytes) != 8:
+            return None
+        key_length = int.from_bytes(key_length_bytes, "little", signed=False)
+
+        key_bytes = handle.read(key_length)
+        if len(key_bytes) != key_length:
+            return None
+        key = key_bytes.decode("utf-8", errors="ignore")
+
+        value_type_bytes = handle.read(4)
+        if len(value_type_bytes) != 4:
+            return None
+        value_type = int.from_bytes(value_type_bytes, "little", signed=False)
+
+        capture_value = key == "general.architecture"
+        try:
+            value = _read_value(handle, value_type, capture_string=capture_value)
+        except ValueError:
+            value = None
+
+        if capture_value:
+            return value
+
+    return None
+
+
+def _read_value(handle: BinaryIO, value_type: int, *, capture_string: bool) -> str | None:
+    if value_type == _TYPE_STRING:
+        length_bytes = handle.read(8)
+        if len(length_bytes) != 8:
+            return None
+        length = int.from_bytes(length_bytes, "little", signed=False)
+        value_bytes = handle.read(length)
+        if len(value_bytes) != length:
+            return None
+        if capture_string:
+            return value_bytes.decode("utf-8", errors="ignore")
+        return None
+
+    if value_type == _TYPE_ARRAY:
+        element_type_bytes = handle.read(4)
+        length_bytes = handle.read(8)
+        if len(element_type_bytes) != 4 or len(length_bytes) != 8:
+            return None
+        element_type = int.from_bytes(element_type_bytes, "little", signed=False)
+        element_count = int.from_bytes(length_bytes, "little", signed=False)
+        for _ in range(element_count):
+            _read_value(handle, element_type, capture_string=False)
+        return None
+
+    size = _SCALAR_BYTE_SIZES.get(value_type)
+    if size is None:
+        raise ValueError(f"Unsupported GGUF metadata type: {value_type}")
+
+    skipped = handle.read(size)
+    if len(skipped) != size:
+        return None
+    return None

--- a/voice_agent/llm/llama_cpp.py
+++ b/voice_agent/llm/llama_cpp.py
@@ -9,9 +9,17 @@ if TYPE_CHECKING:  # pragma: no cover - import used for typing only
     from llama_cpp import Llama
 
 from voice_agent.llm.base import LlmConfig, LlmEngine
+from voice_agent.llm.gguf_metadata import read_general_architecture
 from voice_agent.logging import get_logger
 
 _LOG = get_logger(__name__)
+
+_ARCHITECTURE_GUIDANCE: dict[str, str] = {
+    "lfm2": (
+        "LiquidAI LFM2 GGUF models require a llama.cpp build with Liquid Fourier Mamba support. "
+        "Install LiquidAI's patched llama.cpp distribution or choose a model converted from a supported architecture."
+    ),
+}
 
 
 class LlamaCppEngine(LlmEngine):
@@ -44,6 +52,8 @@ class LlamaCppEngine(LlmEngine):
             )
             raise FileNotFoundError(f"Model missing at {model_path}")
 
+        metadata_architecture = read_general_architecture(model_path)
+
         init_kwargs: Dict[str, object] = {
             "model_path": str(model_path),
             "n_ctx": self._config.context_window,
@@ -53,13 +63,17 @@ class LlamaCppEngine(LlmEngine):
         if self._n_gpu_layers is not None:
             init_kwargs["n_gpu_layers"] = self._n_gpu_layers
 
+        structured_payload = {k: v for k, v in init_kwargs.items() if k != "model_path"}
+        if metadata_architecture:
+            structured_payload["architecture"] = metadata_architecture
+
         _LOG.info(
             "Initialising llama.cpp",
             extra={
                 "classname": self.__class__.__name__,
                 "function": "_initialise_model",
                 "system_section": "llm",
-                "structured_message": str({k: v for k, v in init_kwargs.items() if k != "model_path"}),
+                "structured_message": str(structured_payload),
             },
         )
         from llama_cpp import Llama
@@ -69,12 +83,16 @@ class LlamaCppEngine(LlmEngine):
         except ValueError as exc:
             error_message = str(exc)
             architecture = _extract_unknown_architecture(error_message)
+            if architecture is None:
+                architecture = metadata_architecture
             if architecture:
-                guidance = (
-                    f"Unsupported GGUF architecture '{architecture}' detected. "
-                    "Upgrade llama-cpp-python to >=0.3.16 (or another build that recognises this architecture) "
-                    "or choose a model converted with a supported base architecture."
-                )
+                guidance = _ARCHITECTURE_GUIDANCE.get(architecture)
+                if guidance is None:
+                    guidance = (
+                        f"Unsupported GGUF architecture '{architecture}' detected. "
+                        "Upgrade llama-cpp-python to a build that recognises this architecture "
+                        "or choose a model converted with a supported base architecture."
+                    )
             else:
                 guidance = "llama.cpp failed to load the GGUF model. Verify compatibility."
 


### PR DESCRIPTION
## Summary
- add a lightweight GGUF metadata parser so we can detect the `general.architecture` field before invoking llama.cpp
- surface LiquidAI LFM2-specific guidance when the model architecture is unsupported and include architecture data in structured logs
- extend the llama.cpp unit tests with a minimal GGUF fixture plus metadata inference coverage and update the task checklist

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68eee8b9d1fc832b99cfdfd9fbc26b33