### PR TITLE
Switch default LLM assets to TinyLlama

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A cross-platform (Linux + macOS) voice agent runtime that orchestrates audio I/O
 
 ### Bootstrap
 
-Use the provided script to set up dependencies and fetch baseline models (LFM2-350M + Kitten TTS assets):
+Use the provided script to set up dependencies and fetch baseline models (TinyLlama-1.1B-Chat + Kitten TTS assets):
 
 ```bash
 ./scripts/bootstrap.sh
 ```
 
-The script installs Poetry if missing, configures the environment, and downloads the smallest GGUF along with Kitten TTS Nano 0.2.
+The script installs Poetry if missing, configures the environment, and downloads the TinyLlama GGUF along with Kitten TTS Nano 0.2.
 
 ### Start Build Automation
 
@@ -98,4 +98,4 @@ See [task.md](task.md) for the tracked epics and outstanding work (Silero VAD, W
 
 ## Licensing
 
-This project is distributed under the Apache-2.0 license. Third-party model licenses (LiquidAI LFM2 GGUF, Kitten TTS Nano 0.2) must be reviewed before redistribution.
+This project is distributed under the Apache-2.0 license. Third-party model licenses (TinyLlama Chat GGUF, orca-mini GGUF, Kitten TTS Nano 0.2) must be reviewed before redistribution.

--- a/config/config.toml
+++ b/config/config.toml
@@ -6,7 +6,7 @@ asr_model = "assets/asr/faster-whisper-base"
 asr_device = "cpu"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
+llm_model = "assets/llm/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.7
 llm_top_p = 0.9
@@ -36,7 +36,7 @@ asr_model = "assets/asr/mlx-whisper-small"
 asr_device = "mps"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-700M-GGUF/LFM2-700M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/orca-mini-3b-GGUF/orca-mini-3b.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.8
 llm_top_p = 0.9

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ASSETS_DIR="$PROJECT_ROOT/assets"
-LLM_DIR="$ASSETS_DIR/llm/LiquidAI/LFM2-350M-GGUF"
+LLM_DIR="$ASSETS_DIR/llm/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF"
 TTS_DIR="$ASSETS_DIR/tts/kitten-tts"
 
 python_bin=${PYTHON:-python3}
@@ -20,10 +20,10 @@ poetry install --with dev
 
 mkdir -p "$LLM_DIR" "$TTS_DIR"
 
-LLM_FILE="$LLM_DIR/LFM2-350M-Q4_K_M.gguf"
+LLM_FILE="$LLM_DIR/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf"
 if [ ! -f "$LLM_FILE" ]; then
-  echo "Downloading LFM2-350M GGUF (Q4_K_M)..."
-  curl -L "https://huggingface.co/LiquidAI/LFM2-350M-GGUF/resolve/main/LFM2-350M-Q4_K_M.gguf" -o "$LLM_FILE"
+  echo "Downloading TinyLlama-1.1B-Chat (Q4_K_M)..."
+  curl -L "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf" -o "$LLM_FILE"
 fi
 
 if [ ! -f "$TTS_DIR/kitten_tts_nano_v0_2.onnx" ]; then

--- a/task.md
+++ b/task.md
@@ -33,3 +33,6 @@
 - [x] Fix Faster-Whisper download root handling for Hugging Face-managed assets.
 - [x] Surface unsupported llama.cpp GGUF architecture guidance during model load.
 - [x] Update llama.cpp dependency to support LiquidAI LFM2 GGUF models without changing defaults.
+- [x] Replace default LLM profiles with a llama.cpp-supported architecture and update assets guidance.
+- [x] Align bootstrap downloads and model registry entries with the new default LLM selection.
+- [x] Run project test suite to confirm configuration updates.

--- a/voice_agent/config/default_config.toml
+++ b/voice_agent/config/default_config.toml
@@ -6,7 +6,7 @@ asr_model = "assets/asr/faster-whisper-base"
 asr_device = "cpu"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-350M-GGUF/LFM2-350M-Q4_K_M.gguf"
+llm_model = "assets/llm/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF/TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.7
 llm_top_p = 0.9
@@ -36,7 +36,7 @@ asr_model = "assets/asr/mlx-whisper-small"
 asr_device = "mps"
 
 llm_backend = "llama-cpp"
-llm_model = "assets/llm/LiquidAI/LFM2-700M-GGUF/LFM2-700M-Q4_K_M.gguf"
+llm_model = "assets/llm/TheBloke/orca-mini-3b-GGUF/orca-mini-3b.Q4_K_M.gguf"
 llm_context_window = 2048
 llm_temperature = 0.8
 llm_top_p = 0.9

--- a/voice_agent/models/registry.py
+++ b/voice_agent/models/registry.py
@@ -20,19 +20,19 @@ class ModelEntry:
 
 
 MODEL_REGISTRY: Dict[str, ModelEntry] = {
-    "llm/LiquidAI/LFM2-350M-GGUF": ModelEntry(
-        model_id="llm/LiquidAI/LFM2-350M-GGUF",
-        filename="LFM2-350M-Q4_K_M.gguf",
-        size_mb=356.7,
-        sha256="placeholder-sha256-350m",
-        description="LiquidAI LFM2 350M quantized GGUF",
+    "llm/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF": ModelEntry(
+        model_id="llm/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        filename="TinyLlama-1.1B-Chat-v1.0.Q4_K_M.gguf",
+        size_mb=628.0,
+        sha256="placeholder-sha256-tinyllama",
+        description="TinyLlama 1.1B Chat v1.0 quantized GGUF",
     ),
-    "llm/LiquidAI/LFM2-700M-GGUF": ModelEntry(
-        model_id="llm/LiquidAI/LFM2-700M-GGUF",
-        filename="LFM2-700M-Q4_K_M.gguf",
-        size_mb=702.1,
-        sha256="placeholder-sha256-700m",
-        description="LiquidAI LFM2 700M quantized GGUF",
+    "llm/TheBloke/orca-mini-3b-GGUF": ModelEntry(
+        model_id="llm/TheBloke/orca-mini-3b-GGUF",
+        filename="orca-mini-3b.Q4_K_M.gguf",
+        size_mb=1720.0,
+        sha256="placeholder-sha256-orca-mini-3b",
+        description="orca-mini 3B quantized GGUF",
     ),
     "tts/kitten-nano-0.2/onnx": ModelEntry(
         model_id="tts/kitten-nano-0.2/onnx",


### PR DESCRIPTION
## Summary
- replace the default and fast-mlx LLM profiles with TinyLlama and orca-mini GGUF models that are compatible with stock llama.cpp builds
- refresh the bootstrap script, model registry, and documentation to reference the new baseline downloads
- record the completed configuration migration tasks in task.md

## Testing
- `poetry run pytest`
- `poetry run ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68eeee969024832bb6921a884debff7a