### PR TITLE
Handle optional huggingface_hub dependency for GGUF downloads

### DIFF
--- a/task.md
+++ b/task.md
@@ -4,6 +4,9 @@
 - [x] Implement compatibility handling or guidance for unsupported GGUF architectures in llama.cpp engine.
 - [x] Verify regression coverage and run project test suite after llama.cpp compatibility fixes.
 
+- [x] Handle optional `huggingface_hub` dependency gaps for automatic GGUF downloads.
+- [x] Add regression coverage for Hugging Face asset helper dependency fallbacks.
+
 - [x] Scaffold Python project with Poetry, pyproject, and package structure.
 - [x] Implement structured logging with quality review prompts.
 - [x] Add configuration management with profiles and asset validation.

--- a/tests/test_hf_assets.py
+++ b/tests/test_hf_assets.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from voice_agent.llm import hf_assets
+
+
+class FakeHubError(Exception):
+    pass
+
+
+def test_infer_repo_id_with_category_segment():
+    path = Path("assets/llm/Org/Repo/model.gguf")
+    assert hf_assets._infer_repo_id(path) == "Org/Repo"
+
+
+def test_infer_repo_id_without_category():
+    path = Path("assets/Org/Repo/model.gguf")
+    assert hf_assets._infer_repo_id(path) == "Org/Repo"
+
+
+def test_ensure_local_gguf_missing_dependency(tmp_path, monkeypatch):
+    model_path = tmp_path / "assets" / "llm" / "Org" / "Repo" / "model.gguf"
+
+    def raise_module(name: str):  # pragma: no cover - simple stub
+        raise ModuleNotFoundError(name)
+
+    hf_assets._resolve_hf_client.cache_clear()
+    hf_assets._MISSING_DEPENDENCY_LOGGED = False
+    monkeypatch.setattr(hf_assets, "import_module", raise_module)
+
+    result = hf_assets.ensure_local_gguf(model_path)
+
+    assert result == model_path
+    assert not model_path.exists()
+
+
+def test_ensure_local_gguf_downloads_when_dependency_available(tmp_path, monkeypatch):
+    model_path = tmp_path / "assets" / "llm" / "Org" / "Repo" / "model.gguf"
+    download_calls = {}
+
+    def fake_download(*, repo_id: str, filename: str, local_dir: str, local_dir_use_symlinks: bool, resume_download: bool):
+        download_calls["args"] = (repo_id, filename, local_dir, local_dir_use_symlinks, resume_download)
+        path = Path(local_dir) / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"GGUF")
+        return str(path)
+
+    hf_assets._MISSING_DEPENDENCY_LOGGED = False
+    hf_assets._resolve_hf_client.cache_clear()
+    monkeypatch.setattr(hf_assets, "_resolve_hf_client", lambda: (fake_download, FakeHubError))
+
+    result = hf_assets.ensure_local_gguf(model_path)
+
+    assert result == model_path
+    assert model_path.exists()
+    assert download_calls["args"] == (
+        "Org/Repo",
+        "model.gguf",
+        str(model_path.parent),
+        False,
+        True,
+    )

--- a/voice_agent/llm/hf_assets.py
+++ b/voice_agent/llm/hf_assets.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from functools import lru_cache
+from importlib import import_module
 from pathlib import Path
-from typing import Final
-
-from huggingface_hub import hf_hub_download
-from huggingface_hub.utils import HfHubHTTPError
+from typing import Callable, Final, Optional, Tuple, Type
 
 from voice_agent.logging import get_logger
 
 _LOG = get_logger(__name__)
 
-_DERIVED_MESSAGE: Final[str] = "[Continuous skepticism (Sherlock Protocol)] Attempted Hugging Face GGUF repair"
+_DERIVED_MESSAGE: Final[str] = (
+    "[Continuous skepticism (Sherlock Protocol)]\n"
+    "Quality review checklist\n"
+    "* Could this change affect unexpected files/systems?\n"
+    "* Are all dependencies accounted for without hidden couplings?\n"
+    "* Which edge cases or failure modes still need coverage?\n"
+    "* If blocked, what outcome are we working backward from?"
+)
+
+_HfDownload = Callable[..., str]
+_HfHttpError = Type[Exception]
+
+_MISSING_DEPENDENCY_LOGGED: bool = False
 
 
 def ensure_local_gguf(model_path: Path) -> Path:
@@ -27,6 +38,13 @@ def ensure_local_gguf(model_path: Path) -> Path:
         _log_skip(model_path)
         return model_path
 
+    client = _resolve_hf_client()
+    if client is None:
+        _log_dependency_skip(model_path)
+        return model_path
+
+    hf_hub_download, http_error = client
+
     model_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
@@ -37,11 +55,10 @@ def ensure_local_gguf(model_path: Path) -> Path:
             local_dir_use_symlinks=False,
             resume_download=True,
         )
-    except HfHubHTTPError as exc:  # pragma: no cover - network failures depend on runtime
+    except http_error as exc:  # pragma: no cover - network failures depend on runtime
         _LOG.warning(
             "Hugging Face GGUF download failed",
             extra={
-                "filename": __file__,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "classname": __name__,
                 "function": "ensure_local_gguf",
@@ -50,7 +67,7 @@ def ensure_local_gguf(model_path: Path) -> Path:
                 "error": str(exc),
                 "db_phase": "none",
                 "method": "NONE",
-                "message": f"Quality review: Unable to download {model_path.name} from {repo_id}",
+                "structured_message": f"Quality review: Unable to download {model_path.name} from {repo_id}",
                 "derived_message": _DERIVED_MESSAGE,
             },
         )
@@ -59,7 +76,6 @@ def ensure_local_gguf(model_path: Path) -> Path:
     _LOG.info(
         "Downloaded GGUF model from Hugging Face",
         extra={
-            "filename": __file__,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "classname": __name__,
             "function": "ensure_local_gguf",
@@ -68,7 +84,7 @@ def ensure_local_gguf(model_path: Path) -> Path:
             "error": None,
             "db_phase": "none",
             "method": "NONE",
-            "message": f"Quality review: Downloaded {model_path.name} from {repo_id}",
+            "structured_message": f"Quality review: Downloaded {model_path.name} from {repo_id}",
             "derived_message": _DERIVED_MESSAGE,
         },
     )
@@ -82,12 +98,11 @@ def _infer_repo_id(model_path: Path) -> str | None:
     except ValueError:
         return None
 
-    repo_parts = parts[assets_index + 2 : -1]
-    if len(repo_parts) != 1:
+    repo_parts = parts[assets_index + 1 : -1]
+    if len(repo_parts) < 2:
         return None
 
-    namespace = parts[assets_index + 1]
-    repo = repo_parts[0]
+    namespace, repo = repo_parts[-2], repo_parts[-1]
     if not namespace or not repo:
         return None
 
@@ -98,7 +113,6 @@ def _log_skip(model_path: Path) -> None:
     _LOG.debug(
         "Skipping Hugging Face download for GGUF path",
         extra={
-            "filename": __file__,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "classname": __name__,
             "function": "_log_skip",
@@ -107,7 +121,74 @@ def _log_skip(model_path: Path) -> None:
             "error": None,
             "db_phase": "none",
             "method": "NONE",
-            "message": f"Quality review: Path {model_path} does not map to Hugging Face repo",
+            "structured_message": f"Quality review: Path {model_path} does not map to Hugging Face repo",
+            "derived_message": _DERIVED_MESSAGE,
+        },
+    )
+
+
+@lru_cache(maxsize=1)
+def _resolve_hf_client() -> Optional[Tuple[_HfDownload, _HfHttpError]]:
+    try:
+        hub_module = import_module("huggingface_hub")
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        _log_dependency_missing(str(exc))
+        return None
+
+    download = getattr(hub_module, "hf_hub_download", None)
+    if not callable(download):  # pragma: no cover - defensive
+        _log_dependency_missing("hf_hub_download attribute missing or not callable")
+        return None
+
+    try:
+        utils_module = import_module("huggingface_hub.utils")
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        _log_dependency_missing(str(exc))
+        return None
+
+    http_error = getattr(utils_module, "HfHubHTTPError", None)
+    if not isinstance(http_error, type) or not issubclass(http_error, Exception):  # pragma: no cover - defensive
+        _log_dependency_missing("HfHubHTTPError missing from huggingface_hub.utils")
+        return None
+
+    return download, http_error
+
+
+def _log_dependency_missing(reason: str) -> None:
+    global _MISSING_DEPENDENCY_LOGGED
+    if _MISSING_DEPENDENCY_LOGGED:
+        return
+    _MISSING_DEPENDENCY_LOGGED = True
+    _LOG.warning(
+        "huggingface_hub dependency unavailable",
+        extra={
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "classname": __name__,
+            "function": "_resolve_hf_client",
+            "system_section": "llm",
+            "line_num": 0,
+            "error": reason,
+            "db_phase": "none",
+            "method": "NONE",
+            "structured_message": "Quality review: huggingface_hub not installed; skipping automatic GGUF downloads",
+            "derived_message": _DERIVED_MESSAGE,
+        },
+    )
+
+
+def _log_dependency_skip(model_path: Path) -> None:
+    _LOG.warning(
+        "Skipping Hugging Face download; dependency unavailable",
+        extra={
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "classname": __name__,
+            "function": "ensure_local_gguf",
+            "system_section": "llm",
+            "line_num": 0,
+            "error": None,
+            "db_phase": "none",
+            "method": "NONE",
+            "structured_message": f"Quality review: huggingface_hub missing; cannot download {model_path.name}",
             "derived_message": _DERIVED_MESSAGE,
         },
     )


### PR DESCRIPTION
## Summary
- make the Hugging Face GGUF helper tolerate missing `huggingface_hub` by lazily resolving the client and logging structured fallbacks
- expand GGUF repository inference to handle category folders and emit guidance that matches the Sherlock protocol prompt
- add regression coverage for dependency fallbacks and document the completed task in `task.md`

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ef05b3045c832b8f141f1f3e416093