### PR TITLE
refactor: migrate config validators to pydantic v2

### DIFF
--- a/task.md
+++ b/task.md
@@ -40,3 +40,4 @@
 - [x] Align bootstrap downloads and model registry entries with the new default LLM selection.
 - [x] Run project test suite to confirm configuration updates.
 - [x] Implement automatic Hugging Face downloads for missing llama.cpp GGUF assets.
+- [x] Migrate configuration validators to Pydantic v2 field_validator decorators to prevent deprecation warnings.

--- a/voice_agent/config/models.py
+++ b/voice_agent/config/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Literal
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class AsrConfig(BaseModel):
@@ -13,7 +13,7 @@ class AsrConfig(BaseModel):
     model_path: Path = Field(alias="asr_model")
     device: str = Field(alias="asr_device")
 
-    @validator("model_path")
+    @field_validator("model_path")
     def _check_model_path(cls, value: Path) -> Path:
         if not value:
             raise ValueError("ASR model path is required")
@@ -28,7 +28,7 @@ class LlmConfig(BaseModel):
     top_p: float = Field(alias="llm_top_p", ge=0.0, le=1.0)
     repeat_penalty: float = Field(alias="llm_repeat_penalty", ge=0.5, le=2.0)
 
-    @validator("model_path")
+    @field_validator("model_path")
     def _check_llm_path(cls, value: Path) -> Path:
         if not value:
             raise ValueError("LLM model path is required")
@@ -57,7 +57,7 @@ class TtsConfig(BaseModel):
     chunk_min_ms: int
     chunk_max_gap_ms: int
 
-    @validator("model_dir")
+    @field_validator("model_dir")
     def _check_model_dir(cls, value: Path) -> Path:
         if not value:
             raise ValueError("TTS model_dir is required")


### PR DESCRIPTION
## Summary
- replace deprecated `@validator` usage with Pydantic v2 `@field_validator` across configuration models
- update the project task tracker to record completion of the validator migration work

## Testing
- poetry run ruff check
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_69015df5d438832b850f5e52322c7925